### PR TITLE
Fix line endings issues when checking out on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# make sure that all line endings of shell scripts are "lf" to avoid "file not found" errors on linux and in docker containers
+*.sh text eol=lf


### PR DESCRIPTION
This PR adds a .gitattributes file that ensures that all shell scripts have "LF" line endings when checking out the repository, even on Windows. This fixes the "file not found" issues in docker containers and on Linux if the shell scripts in the repository have the wrong line endings.