### PR TITLE
Feature/minio

### DIFF
--- a/plugins/minio-storage.py
+++ b/plugins/minio-storage.py
@@ -1,0 +1,137 @@
+# Copyright 2022 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Sized
+from datetime import timedelta
+from pathlib import Path
+from typing import IO, BinaryIO, Optional, TextIO, Union, cast
+
+from flask import Flask
+
+from qhana_plugin_runner.db.models.tasks import TaskFile
+from qhana_plugin_runner.storage import FileStore
+from qhana_plugin_runner.util.plugins import QHAnaPluginBase
+
+__version__ = "v0.1.0"
+
+
+class HelloWorld(QHAnaPluginBase):
+    """A plugin providing a minio storage provider."""
+
+    name = "minio-storage"
+    version = __version__
+
+    def __init__(self, app: Optional[Flask]) -> None:
+        super().__init__(app)
+
+    def get_requirements(self) -> str:
+        return "minio"
+
+
+import minio
+
+
+class TextFileWrapper(BinaryIO):
+    """A minimal wrapper around string io to produce bytes output."""
+
+    def __init__(self, file_: TextIO):
+        self._file = file_
+
+    def read(self, *args):
+        return self._file.read(*args).encode()
+
+
+class MinioStore(FileStore, name="minio"):
+    """A file store implementation using minio backend.
+
+    Set the config option `DEFAULT_FILE_STORE` to "minio" to set this as the
+    default file store.
+
+    The minio client can be configured with the `MINIO_CLIENT` config key.
+    The configuration is a mapping that is directly passed to `minio.Minio()`.
+
+    All files will be stored in a single bucket. The bucket and all other
+    settings of the storage provider use the `MINIO` config key. The default
+    bucket can be configured by the setting `MINIO.bucket="custom-bucket"`.
+    """
+
+    def __init__(self, app: Flask) -> None:
+        super().__init__(app=app)
+        self._client: Optional[minio.Minio] = None
+        self._minio_bucket: Optional[str] = None
+
+    def init_app(self, app: Flask):
+        """Init the file store with the Flask app to get access to the flask config."""
+        super().init_app(app)
+        minio_config = app.config.get("MINIO_CLIENT", {})
+        if not minio_config:
+            raise ValueError("No configuration for the minio file store found.")
+        self._minio_bucket = app.config.get("MINIO", {}).get("bucket", "experiment-data")
+        self._client = minio.Minio(**minio_config)
+        if not self._client.bucket_exists(self._minio_bucket):
+            self._client.make_bucket(self._minio_bucket)
+
+    def persist_file(
+        self,
+        file_: IO,
+        target: Union[str, Path],
+        mimetype: str = "application/octet-stream",
+    ):
+        is_text = isinstance(file_, TextIO) or (
+            hasattr(file_, "mode") and "b" not in file_.mode
+        )
+
+        if hasattr(file_, "seek") and callable(file_.seek):
+            try:  # seek to beginning of a file (useful for in memory temp files that were just written)
+                file_.seek(0)
+            except Exception:
+                pass  # assume the file object does not support seek
+
+        length = len(file_) if isinstance(file_, Sized) else -1
+
+        if self._client is None:
+            raise ValueError("Client not configured!")
+
+        if is_text:
+            # wrap text io objects to produce bytes on read
+            file_ = TextFileWrapper(cast(TextIO, file_))
+
+        extra_args = {}
+
+        if length < 0:
+            # part size >5MiB must be set if the size is unknown
+            extra_args["part_size"] = 2 ** 25
+
+        self._client.put_object(
+            self._minio_bucket,
+            str(target),
+            file_,
+            length=length,
+            content_type=mimetype,
+            **extra_args,
+        )
+
+    def get_file_url(self, file_storage_data: str, external: bool = True) -> str:
+        if self._client is None:
+            raise ValueError("Client not configured!")
+
+        return self._client.get_presigned_url(
+            "GET",
+            self._minio_bucket,
+            file_storage_data,
+            expires=timedelta(days=(3 if external else 7)),
+        )
+
+    def get_task_file_url(self, file_info: TaskFile, external: bool = True) -> str:
+        return super().get_task_file_url(file_info, external=external)

--- a/qhana_plugin_runner/api/plugins_api.py
+++ b/qhana_plugin_runner/api/plugins_api.py
@@ -68,7 +68,7 @@ class PluginsView(MethodView):
     def get(self):
         """Get all loaded plugins."""
         plugins = sorted(
-            QHAnaPluginBase.get_plugins().values(),
+            (p for p in QHAnaPluginBase.get_plugins().values() if p.has_api),
             key=lambda p: (p.name, p.parsed_version),
         )
         return PluginCollectionData(

--- a/qhana_plugin_runner/storage.py
+++ b/qhana_plugin_runner/storage.py
@@ -368,8 +368,18 @@ class FileStoreRegistry(FileStoreInterface):
         """Init the file store with the Flask app to get access to the flask config."""
         self.app = app
         self._set_default_store_from_config()
-        for store in self._stores.values():
-            store.init_app(app)
+        failed_stores = set()
+        for key, store in self._stores.items():
+            try:
+                store.init_app(app)
+            except:
+                app.logger.warning(
+                    f"Failed to initialize File Store '{key}'. The file store will be removed.",
+                    exc_info=True,
+                )
+                failed_stores.add(key)
+        for key in failed_stores:
+            del self._stores[key]
 
     def _set_default_store_from_config(self):
         """Read and set the default store implementation to use from flask config."""

--- a/qhana_plugin_runner/util/plugins.py
+++ b/qhana_plugin_runner/util/plugins.py
@@ -36,6 +36,7 @@ class QHAnaPluginBase:
     name: ClassVar[str]
     version: ClassVar[str]
     instance: ClassVar["QHAnaPluginBase"]
+    has_api: ClassVar[bool] = False
 
     __app__: Optional[Flask] = None
     __plugins__: Dict[str, "QHAnaPluginBase"] = {}
@@ -243,8 +244,13 @@ def register_plugins(app: Flask):
 
     # register API blueprints (only do this after the API is registered with flask!)
     for plugin in QHAnaPluginBase.get_plugins().values():
-        plugin_blueprint: Optional[Blueprint] = plugin.get_api_blueprint()
+        plugin_blueprint: Optional[Blueprint] = None
+        try:
+            plugin_blueprint = plugin.get_api_blueprint()
+        except NotImplementedError:
+            pass
         if plugin_blueprint:
+            type(plugin).has_api = True
             ROOT_API.register_blueprint(
                 plugin_blueprint, url_prefix=f"{url_prefix}/plugins/{plugin.identifier}/"
             )


### PR DESCRIPTION
This PR adds a minio plugin that allows to store task data in a minio instance.

The plugin can be tested with a minio docker container:

```bash
docker run -p 9000:9000 -p 9001:9001 -e "MINIO_ROOT_USER=QHANA" -e "MINIO_ROOT_PASSWORD=QHANAQHANA" quay.io/minio/minio server /data --console-address ":9001"
```
 Configure the plugin runner as follows (in instance/config.toml):

```toml
DEFAULT_FILE_STORE="minio"

[MINIO_CLIENT]
endpoint="localhost:9000"
access_key="QHANA"
secret_key="QHANAQHANA"
# secure false to bypass tls checks as the development container has no certificate
secure=false
```

Motivation for the plugin: Currently the plugin runner API server and worker containers have to use a shared file system. Now they can use a shared minio container. This should allow multiple plugin runners with different plugin configurations to share all resources (minio storage, redis broker, and database).