### PR TITLE
add paper** as tag for automated build

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,6 +5,7 @@ on:
             - main
         tags:
             - v*
+            - paper**
 
 env:
     REGISTRY: ghcr.io


### PR DESCRIPTION
Enable automated build of paper tags, see e.g. https://github.com/UST-QuAntiL/nisq-analyzer/releases/tag/paper%2Fprioritization