### PR TITLE
Fix import errors of plugins

### DIFF
--- a/plugins/costume_loader_pkg/__init__.py
+++ b/plugins/costume_loader_pkg/__init__.py
@@ -48,7 +48,7 @@ class CostumeLoader(QHAnaPluginBase):
 try:
     # It is important to import the routes **after** COSTUME_LOADER_BLP and CostumeLoader are defined, because they are
     # accessed as soon as the routes are imported.
-    from .routes import *
+    from . import routes
 except ImportError:
     # When running `poetry run flask install`, importing the routes will fail, because the dependencies are not
     # installed yet.

--- a/plugins/costume_loader_pkg/__init__.py
+++ b/plugins/costume_loader_pkg/__init__.py
@@ -48,7 +48,7 @@ class CostumeLoader(QHAnaPluginBase):
 try:
     # It is important to import the routes **after** COSTUME_LOADER_BLP and CostumeLoader are defined, because they are
     # accessed as soon as the routes are imported.
-    import plugins.costume_loader_pkg.routes
+    from .routes import *
 except ImportError:
     # When running `poetry run flask install`, importing the routes will fail, because the dependencies are not
     # installed yet.

--- a/plugins/costume_loader_pkg/backend/attribute.py
+++ b/plugins/costume_loader_pkg/backend/attribute.py
@@ -1,7 +1,7 @@
 import enum
 import logging
-from typing import Any, Optional
-from plugins.costume_loader_pkg.backend.taxonomy import Taxonomy, TaxonomyType
+from typing import Optional
+from .taxonomy import TaxonomyType
 
 """
 This class is an enum for all attributes.

--- a/plugins/costume_loader_pkg/backend/database.py
+++ b/plugins/costume_loader_pkg/backend/database.py
@@ -5,7 +5,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.automap import automap_base, AutomapBase
 from sqlalchemy.orm import Session, DeclarativeMeta
 
-from plugins.costume_loader_pkg.backend.singleton import Singleton
+from .singleton import Singleton
 
 
 class Database(Singleton):

--- a/plugins/costume_loader_pkg/backend/entity.py
+++ b/plugins/costume_loader_pkg/backend/entity.py
@@ -9,8 +9,8 @@ from sqlalchemy import select, and_, join, func
 from sqlalchemy.orm import DeclarativeMeta
 from sqlalchemy.sql import expression
 
-from plugins.costume_loader_pkg.backend.attribute import Attribute
-from plugins.costume_loader_pkg.backend.database import Database
+from .attribute import Attribute
+from .database import Database
 
 MUSE_URL = "http://129.69.214.108/"
 

--- a/plugins/costume_loader_pkg/backend/taxonomy.py
+++ b/plugins/costume_loader_pkg/backend/taxonomy.py
@@ -6,7 +6,7 @@ from typing import Tuple
 from sqlalchemy import text
 from sqlalchemy.sql.elements import TextClause
 
-from plugins.costume_loader_pkg.backend.database import Database
+from .database import Database
 
 
 class TaxonomyType(Enum):

--- a/plugins/costume_loader_pkg/routes.py
+++ b/plugins/costume_loader_pkg/routes.py
@@ -3,7 +3,6 @@ from typing import Mapping
 
 import flask
 from celery.canvas import chain
-from celery.result import AsyncResult
 from flask import Response, redirect
 from flask.globals import request
 from flask.helpers import url_for
@@ -11,13 +10,9 @@ from flask.templating import render_template
 from flask.views import MethodView
 from marshmallow import EXCLUDE
 
-from plugins.costume_loader_pkg import COSTUME_LOADER_BLP, CostumeLoader
-from plugins.costume_loader_pkg.schemas import (
-    InputParameters,
-    InputParametersSchema,
-    TaskResponseSchema,
-)
-from plugins.costume_loader_pkg.tasks import loading_task
+from . import COSTUME_LOADER_BLP, CostumeLoader
+from .schemas import InputParameters, InputParametersSchema, TaskResponseSchema
+from .tasks import loading_task
 from qhana_plugin_runner.api.plugin_schemas import (
     DataMetadata,
     EntryPoint,

--- a/plugins/costume_loader_pkg/tasks.py
+++ b/plugins/costume_loader_pkg/tasks.py
@@ -5,17 +5,13 @@ from zipfile import ZipFile
 
 import flask
 from celery.utils.log import get_task_logger
-from plugins.costume_loader_pkg.backend.attribute import Attribute
-from plugins.costume_loader_pkg.backend.database import Database
-from plugins.costume_loader_pkg.backend.entity import EntityFactory
+from .backend.attribute import Attribute
+from .backend.database import Database
+from .backend.entity import EntityFactory
 
-from plugins.costume_loader_pkg import CostumeLoader
-from plugins.costume_loader_pkg.backend.taxonomy import Taxonomy, TaxonomyType
-from plugins.costume_loader_pkg.schemas import (
-    InputParametersSchema,
-    InputParameters,
-    CostumeType,
-)
+from . import CostumeLoader
+from .backend.taxonomy import Taxonomy, TaxonomyType
+from .schemas import InputParametersSchema, InputParameters, CostumeType
 from qhana_plugin_runner.celery import CELERY
 from qhana_plugin_runner.db.models.tasks import ProcessingTask
 from qhana_plugin_runner.plugin_utils.attributes import AttributeMetadata

--- a/plugins/hello_worl_multi_step/__init__.py
+++ b/plugins/hello_worl_multi_step/__init__.py
@@ -33,7 +33,7 @@ class HelloWorldMultiStep(QHAnaPluginBase):
 try:
     # It is important to import the routes **after** COSTUME_LOADER_BLP and CostumeLoader are defined, because they are
     # accessed as soon as the routes are imported.
-    import plugins.hello_worl_multi_step.routes
+    from .routes import *
 except ImportError:
     # When running `poetry run flask install`, importing the routes will fail, because the dependencies are not
     # installed yet.

--- a/plugins/hello_worl_multi_step/__init__.py
+++ b/plugins/hello_worl_multi_step/__init__.py
@@ -33,7 +33,7 @@ class HelloWorldMultiStep(QHAnaPluginBase):
 try:
     # It is important to import the routes **after** COSTUME_LOADER_BLP and CostumeLoader are defined, because they are
     # accessed as soon as the routes are imported.
-    from .routes import *
+    from . import routes
 except ImportError:
     # When running `poetry run flask install`, importing the routes will fail, because the dependencies are not
     # installed yet.

--- a/plugins/hello_worl_multi_step/routes.py
+++ b/plugins/hello_worl_multi_step/routes.py
@@ -11,12 +11,9 @@ from flask.templating import render_template
 from flask.views import MethodView
 from marshmallow import EXCLUDE
 
-from plugins.hello_worl_multi_step import HELLO_MULTI_BLP, HelloWorldMultiStep
-from plugins.hello_worl_multi_step.schemas import (
-    HelloWorldParametersSchema,
-    TaskResponseSchema,
-)
-from plugins.hello_worl_multi_step.tasks import preprocessing_task, processing_task
+from . import HELLO_MULTI_BLP, HelloWorldMultiStep
+from .schemas import HelloWorldParametersSchema, TaskResponseSchema
+from .tasks import preprocessing_task, processing_task
 from qhana_plugin_runner.api.plugin_schemas import (
     EntryPoint,
     PluginMetadata,

--- a/plugins/hello_worl_multi_step/tasks.py
+++ b/plugins/hello_worl_multi_step/tasks.py
@@ -5,7 +5,7 @@ from json import loads
 
 from celery.utils.log import get_task_logger
 
-from plugins.hello_worl_multi_step import HelloWorldMultiStep
+from . import HelloWorldMultiStep
 from qhana_plugin_runner.celery import CELERY
 from qhana_plugin_runner.db.models.tasks import ProcessingTask
 

--- a/plugins/hybrid_ae_pkg/__init__.py
+++ b/plugins/hybrid_ae_pkg/__init__.py
@@ -48,7 +48,7 @@ class HybridAutoencoderPlugin(QHAnaPluginBase):
 try:
     # It is important to import the routes **after** COSTUME_LOADER_BLP and CostumeLoader are defined, because they are
     # accessed as soon as the routes are imported.
-    from .routes import *
+    from . import routes
 except ImportError:
     # When running `poetry run flask install`, importing the routes will fail, because the dependencies are not
     # installed yet.

--- a/plugins/hybrid_ae_pkg/__init__.py
+++ b/plugins/hybrid_ae_pkg/__init__.py
@@ -48,7 +48,7 @@ class HybridAutoencoderPlugin(QHAnaPluginBase):
 try:
     # It is important to import the routes **after** COSTUME_LOADER_BLP and CostumeLoader are defined, because they are
     # accessed as soon as the routes are imported.
-    import plugins.hybrid_ae_pkg.routes
+    from .routes import *
 except ImportError:
     # When running `poetry run flask install`, importing the routes will fail, because the dependencies are not
     # installed yet.

--- a/plugins/hybrid_ae_pkg/backend/main.py
+++ b/plugins/hybrid_ae_pkg/backend/main.py
@@ -9,7 +9,7 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torch.utils.data import DataLoader
 
-from plugins.hybrid_ae_pkg.backend.quantum.qiskit.hybrid import ClassicalAutoEncoder
+from .quantum.qiskit.hybrid import ClassicalAutoEncoder
 
 
 # TODO: dont train in the 0th epoch

--- a/plugins/hybrid_ae_pkg/backend/quantum/pl/QNN1.py
+++ b/plugins/hybrid_ae_pkg/backend/quantum/pl/QNN1.py
@@ -3,7 +3,7 @@ from typing import Tuple, Callable, List
 import pennylane as qml
 import pennylane.numpy as np
 
-from plugins.hybrid_ae_pkg.backend.quantum.pl.TwoQubitGate import add_two_qubit_gate
+from .TwoQubitGate import add_two_qubit_gate
 
 
 def constructor(q_num: int) -> Tuple[Callable, int]:

--- a/plugins/hybrid_ae_pkg/backend/quantum/pl/pytorch/models/common_functions.py
+++ b/plugins/hybrid_ae_pkg/backend/quantum/pl/pytorch/models/common_functions.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 import pennylane as qml
 
-from plugins.hybrid_ae_pkg.backend.quantum.pl import QNN1, QNN2, QNN3
+from ... import QNN1, QNN2, QNN3
 
 
 def create_qlayer(

--- a/plugins/hybrid_ae_pkg/backend/quantum/pl/pytorch/models/hybrid.py
+++ b/plugins/hybrid_ae_pkg/backend/quantum/pl/pytorch/models/hybrid.py
@@ -6,10 +6,7 @@ from typing import Iterator, Dict, List, Union, BinaryIO, IO
 import torch
 import pennylane as qml
 
-from plugins.hybrid_ae_pkg.backend.quantum.pl.pytorch.models.common_functions import (
-    create_qlayer,
-    qnn_constructors,
-)
+from .common_functions import create_qlayer, qnn_constructors
 
 
 class HybridAutoencoder(torch.nn.Module):

--- a/plugins/hybrid_ae_pkg/backend/quantum/pl/pytorch/training.py
+++ b/plugins/hybrid_ae_pkg/backend/quantum/pl/pytorch/training.py
@@ -6,7 +6,7 @@ import torch
 from torch.optim import Optimizer
 from torch.utils.data import TensorDataset, DataLoader
 
-from plugins.hybrid_ae_pkg.backend.helpers import save_optim_state
+from ....helpers import save_optim_state
 from qhana_plugin_runner.storage import STORE
 
 

--- a/plugins/hybrid_ae_pkg/backend/quantum/qiskit/autograd.py
+++ b/plugins/hybrid_ae_pkg/backend/quantum/qiskit/autograd.py
@@ -3,7 +3,7 @@ import math
 
 import torch
 
-from plugins.hybrid_ae_pkg.backend.quantum.qiskit.autoencoder import QuantumAutoencoder
+from .autoencoder import QuantumAutoencoder
 
 
 # TODO: measure performance

--- a/plugins/hybrid_ae_pkg/backend/quantum/qiskit/hybrid.py
+++ b/plugins/hybrid_ae_pkg/backend/quantum/qiskit/hybrid.py
@@ -5,8 +5,8 @@ from typing import List, Optional
 
 import numpy as np
 import torch
-from plugins.hybrid_ae_pkg.backend.quantum.qiskit.autoencoder import QuantumAutoencoder
-from plugins.hybrid_ae_pkg.backend.quantum.qiskit.autograd import QAEModule
+from .autoencoder import QuantumAutoencoder
+from .autograd import QAEModule
 from torch.utils.data import Dataset, Sampler
 
 

--- a/plugins/hybrid_ae_pkg/backend/simple_api.py
+++ b/plugins/hybrid_ae_pkg/backend/simple_api.py
@@ -6,18 +6,12 @@ import torch
 from torch.optim import Adam, Optimizer
 from torch.utils.data import DataLoader, TensorDataset, RandomSampler
 
-from plugins.hybrid_ae_pkg.backend.main import train_nn as training_loop
-from plugins.hybrid_ae_pkg.backend.quantum.pl.pytorch.models.hybrid import (
-    HybridAutoencoder as PLHybridAutoencoder,
-)
-from plugins.hybrid_ae_pkg.backend.quantum.pl.pytorch.training import (
-    training_loop as pl_training_loop,
-)
-from plugins.hybrid_ae_pkg.backend.quantum.qiskit.autoencoder import (
-    QuantumAutoencoder as QKQuantumAutoencoder,
-)
-from plugins.hybrid_ae_pkg.backend.quantum.qiskit.autograd import QAEModule
-from plugins.hybrid_ae_pkg.backend.quantum.qiskit.hybrid import (
+from .main import train_nn as training_loop
+from .quantum.pl.pytorch.models.hybrid import HybridAutoencoder as PLHybridAutoencoder
+from .quantum.pl.pytorch.training import training_loop as pl_training_loop
+from .quantum.qiskit.autoencoder import QuantumAutoencoder as QKQuantumAutoencoder
+from .quantum.qiskit.autograd import QAEModule
+from .quantum.qiskit.hybrid import (
     ClassicalAutoEncoder as QKClassicalAutoEncoder,
     HybridAutoencoder as QKHybridAutoencoder,
 )

--- a/plugins/hybrid_ae_pkg/routes.py
+++ b/plugins/hybrid_ae_pkg/routes.py
@@ -8,9 +8,9 @@ from flask import url_for, request, Response, render_template, redirect
 from flask.views import MethodView
 from marshmallow import EXCLUDE
 
-from plugins.hybrid_ae_pkg import HybridAutoencoderPlugin, HA_BLP
-from plugins.hybrid_ae_pkg.tasks import hybrid_autoencoder_pennylane_task
-from plugins.hybrid_ae_pkg.schemas import (
+from . import HybridAutoencoderPlugin, HA_BLP
+from .tasks import hybrid_autoencoder_pennylane_task
+from .schemas import (
     HybridAutoencoderTaskResponseSchema,
     HybridAutoencoderPennylaneRequestSchema,
 )

--- a/plugins/hybrid_ae_pkg/tasks.py
+++ b/plugins/hybrid_ae_pkg/tasks.py
@@ -5,7 +5,7 @@ from typing import Dict
 from celery.utils.log import get_task_logger
 from sqlalchemy import select
 
-from plugins.hybrid_ae_pkg import HybridAutoencoderPlugin
+from . import HybridAutoencoderPlugin
 from qhana_plugin_runner.celery import CELERY
 from qhana_plugin_runner.db import DB
 from qhana_plugin_runner.db.models.tasks import ProcessingTask
@@ -22,7 +22,7 @@ TASK_LOGGER = get_task_logger(__name__)
 )
 def hybrid_autoencoder_pennylane_task(self, db_id: int) -> str:
     import numpy as np
-    from plugins.hybrid_ae_pkg.backend import simple_api
+    from .backend import simple_api
 
     TASK_LOGGER.info(
         f"Starting new hybrid autoencoder pennylane task with db id '{db_id}'"

--- a/plugins/manual_classification/__init__.py
+++ b/plugins/manual_classification/__init__.py
@@ -35,7 +35,7 @@ class ManualClassification(QHAnaPluginBase):
 try:
     # It is important to import the routes **after** COSTUME_LOADER_BLP and CostumeLoader are defined, because they are
     # accessed as soon as the routes are imported.
-    import plugins.manual_classification.routes
+    from .routes import *
 except ImportError:
     # When running `poetry run flask install`, importing the routes will fail, because the dependencies are not
     # installed yet.

--- a/plugins/manual_classification/__init__.py
+++ b/plugins/manual_classification/__init__.py
@@ -35,7 +35,7 @@ class ManualClassification(QHAnaPluginBase):
 try:
     # It is important to import the routes **after** COSTUME_LOADER_BLP and CostumeLoader are defined, because they are
     # accessed as soon as the routes are imported.
-    from .routes import *
+    from . import routes
 except ImportError:
     # When running `poetry run flask install`, importing the routes will fail, because the dependencies are not
     # installed yet.

--- a/plugins/manual_classification/routes.py
+++ b/plugins/manual_classification/routes.py
@@ -20,8 +20,8 @@ from qhana_plugin_runner.api.plugin_schemas import (
     DataMetadata,
 )
 
-from plugins.manual_classification import MANUAL_CLASSIFICATION_BLP, ManualClassification
-from plugins.manual_classification.schemas import (
+from . import MANUAL_CLASSIFICATION_BLP, ManualClassification
+from .schemas import (
     ResponseSchema,
     TaskResponseSchema,
     LoadParametersSchema,
@@ -34,11 +34,7 @@ from qhana_plugin_runner.tasks import (
     save_task_result,
 )
 
-from plugins.manual_classification.tasks import (
-    pre_render_classification,
-    add_class,
-    save_classification,
-)
+from .tasks import pre_render_classification, add_class, save_classification
 
 
 TASK_LOGGER = get_task_logger(__name__)

--- a/plugins/manual_classification/tasks.py
+++ b/plugins/manual_classification/tasks.py
@@ -6,7 +6,7 @@ import mimetypes
 
 from celery.utils.log import get_task_logger
 
-from plugins.manual_classification import ManualClassification
+from . import ManualClassification
 from qhana_plugin_runner.celery import CELERY
 from qhana_plugin_runner.db.models.tasks import ProcessingTask
 

--- a/plugins/quantum_k_means/__init__.py
+++ b/plugins/quantum_k_means/__init__.py
@@ -34,7 +34,7 @@ class QKMeans(QHAnaPluginBase):
 try:
     # It is important to import the routes **after** COSTUME_LOADER_BLP and CostumeLoader are defined, because they are
     # accessed as soon as the routes are imported.
-    from .routes import *
+    from . import routes
 except ImportError:
     # When running `poetry run flask install`, importing the routes will fail, because the dependencies are not
     # installed yet.

--- a/plugins/quantum_k_means/__init__.py
+++ b/plugins/quantum_k_means/__init__.py
@@ -34,7 +34,7 @@ class QKMeans(QHAnaPluginBase):
 try:
     # It is important to import the routes **after** COSTUME_LOADER_BLP and CostumeLoader are defined, because they are
     # accessed as soon as the routes are imported.
-    import plugins.quantum_k_means.routes
+    from .routes import *
 except ImportError:
     # When running `poetry run flask install`, importing the routes will fail, because the dependencies are not
     # installed yet.

--- a/plugins/quantum_k_means/backend/clustering.py
+++ b/plugins/quantum_k_means/backend/clustering.py
@@ -7,7 +7,7 @@ import pennylane as qml
 from celery.utils.log import get_task_logger
 from qiskit import IBMQ
 
-from plugins.quantum_k_means.backend.quantumKMeans import (
+from .quantumKMeans import (
     NegativeRotationQuantumKMeans,
     DestructiveInterferenceQuantumKMeans,
     StatePreparationQuantumKMeans,

--- a/plugins/quantum_k_means/backend/quantumKMeans.py
+++ b/plugins/quantum_k_means/backend/quantumKMeans.py
@@ -5,7 +5,7 @@ import numpy as np
 # import matplotlib.pyplot as plt
 import pennylane as qml
 import random
-from plugins.quantum_k_means.backend.tools import pl_samples_to_counts
+from .tools import pl_samples_to_counts
 
 
 TASK_LOGGER = get_task_logger(__name__)

--- a/plugins/quantum_k_means/routes.py
+++ b/plugins/quantum_k_means/routes.py
@@ -12,9 +12,9 @@ from flask.templating import render_template
 from flask.views import MethodView
 from marshmallow import EXCLUDE
 
-from plugins.quantum_k_means import QKMEANS_BLP, QKMeans
-from plugins.quantum_k_means.backend.clustering import QuantumBackends
-from plugins.quantum_k_means.schemas import InputParametersSchema, TaskResponseSchema
+from . import QKMEANS_BLP, QKMeans
+from .backend.clustering import QuantumBackends
+from .schemas import InputParametersSchema, TaskResponseSchema
 from qhana_plugin_runner.api.plugin_schemas import (
     DataMetadata,
     EntryPoint,
@@ -25,7 +25,7 @@ from qhana_plugin_runner.api.plugin_schemas import (
 from qhana_plugin_runner.db.models.tasks import ProcessingTask
 from qhana_plugin_runner.tasks import save_task_error, save_task_result
 
-from plugins.quantum_k_means.tasks import calculation_task
+from .tasks import calculation_task
 
 
 @QKMEANS_BLP.route("/")

--- a/plugins/quantum_k_means/schemas.py
+++ b/plugins/quantum_k_means/schemas.py
@@ -3,7 +3,7 @@ from enum import Enum
 import marshmallow as ma
 from marshmallow import post_load
 
-from plugins.quantum_k_means.backend.clustering import QuantumBackends
+from .backend.clustering import QuantumBackends
 from qhana_plugin_runner.api import EnumField
 from qhana_plugin_runner.api.util import (
     FrontendFormBaseSchema,

--- a/plugins/quantum_k_means/tasks.py
+++ b/plugins/quantum_k_means/tasks.py
@@ -5,19 +5,15 @@ from typing import Optional
 
 from celery.utils.log import get_task_logger
 
-from plugins.quantum_k_means import QKMeans
-from plugins.quantum_k_means.backend.clustering import (
+from . import QKMeans
+from .backend.clustering import (
     Clustering,
     NegativeRotationQuantumKMeansClustering,
     DestructiveInterferenceQuantumKMeansClustering,
     StatePreparationQuantumKMeansClustering,
     PositiveCorrelationQuantumKMeansClustering,
 )
-from plugins.quantum_k_means.schemas import (
-    InputParameters,
-    InputParametersSchema,
-    VariantEnum,
-)
+from .schemas import InputParameters, InputParametersSchema, VariantEnum
 from qhana_plugin_runner.celery import CELERY
 from qhana_plugin_runner.db.models.tasks import ProcessingTask
 from qhana_plugin_runner.plugin_utils.entity_marshalling import (


### PR DESCRIPTION
This PR fixes the import errors when loading plugins from a folder other than the plugins folder. This happens e.g. when using the QHAna Docker setup.

To fix this issue, the absolute imports in the plugins, that imported files from the plugin itself, were replaced by relative imports.