### PR TITLE
Add pandas for pip to install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN python -m venv ${VIRTUAL_ENV}
 # change path to include virtualenv first (affects all following commands)
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
-RUN python -m pip install --upgrade pip && python -m pip install gunicorn poetry invoke
+RUN python -m pip install --upgrade pip && python -m pip install gunicorn poetry invoke pandas
 
 COPY --chown=gunicorn . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN python -m venv ${VIRTUAL_ENV}
 # change path to include virtualenv first (affects all following commands)
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
-RUN python -m pip install --upgrade pip && python -m pip install gunicorn poetry invoke pandas
+RUN python -m pip install --upgrade pip && python -m pip install gunicorn poetry invoke
 
 COPY --chown=gunicorn . /app
 

--- a/plugins/visualization.py
+++ b/plugins/visualization.py
@@ -244,7 +244,7 @@ class VIS(QHAnaPluginBase):
         return VIS_BLP
 
     def get_requirements(self) -> str:
-        return "plotly~=5.3.1"
+        return "plotly~=5.3.1\npandas~=1.4.2"
 
 
 TASK_LOGGER = get_task_logger(__name__)


### PR DESCRIPTION
When I tried visualizing some data in `qhana-docker`, the `qhana-plugin-runner` had an internal error.

```
worker_1               | [2022-05-18 13:49:39,377: ERROR/MainProcess] Sub-Task edfa99a0-db84-4a7c-b64a-89e17f317d9d of Task with db id 14 raised exception: ModuleNotFoundError("No module named 'pandas'")
worker_1               | Traceback (most recent call last):
worker_1               |   File "/venv/lib/python3.9/site-packages/celery/app/trace.py", line 451, in trace_task
worker_1               |     R = retval = fun(*args, **kwargs)
worker_1               |   File "/app/qhana_plugin_runner/celery.py", line 41, in __call__
worker_1               |     return self.run(*args, **kwargs)
worker_1               |   File "/app/git-plugins/visualization.py", line 255, in calculation_task
worker_1               |     import pandas as pd
worker_1               | ModuleNotFoundError: No module named 'pandas'
```

Adding `pandas` to the Dockerfile fixed it for me.