### PR TITLE
Add GitHub workflow to build Docker images for the mini MUSE database

### DIFF
--- a/.github/workflows/mini_muse_image.yml
+++ b/.github/workflows/mini_muse_image.yml
@@ -1,0 +1,39 @@
+name: Build and Push Mini MUSE Image
+on: [workflow_dispatch]
+
+env:
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{ github.repository_owner }}/mini-muse
+
+jobs:
+  build_image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: ./plugins/costume_loader_pkg/db_container/
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -369,16 +369,6 @@ docker-compose down
 
 To also delete the volume containing the output files add the flag `-v`.
 
-#### Docker Compose with MUSE database
-
-If you want to start the MUSE database as well you need to build the muse-db image. 
-As a prerequisite you need to have a `mini-muse.sql` file in `plugins/costume_loader_pkg/db_container` and build the Dockerfile that is in the same folder with `docker build -t muse-db plugins/costume_loader_pkg/db_container`.
-Then you can start everything with
-
-```
-docker-compose --profile with_db up
-```
-
 
 ## Acknowledgements
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,7 @@ services:
       POSTGRES_USER: user
       POSTGRES_DB: default_db
   muse-db:
-    image: "muse-db"
-    profiles:
-      - with_db
+    image: ghcr.io/ust-quantil/mini-muse:main
   worker:
     build: .
     image: qhana-plugin-runner


### PR DESCRIPTION
With this PR, images for the mini MUSE database can be build with a GitHub workflow. This workflow needs to be manually triggered to avoid unnecessary builds and because changes to the mini MUSE database are expected to be infrequent.