### PR TITLE
Refactor entity to tuple parsing to be more robust

### DIFF
--- a/qhana_plugin_runner/util/config/__init__.py
+++ b/qhana_plugin_runner/util/config/__init__.py
@@ -65,5 +65,4 @@ class DebugConfig(ProductionConfig, SQLAchemyDebugConfig, SmorestDebugConfig):
 
     CELERY = CELERY_DEBUG_CONFIG
 
-    # TODO allow specifying this as a Environment variable
     PLUGIN_FOLDERS = ["./plugins", "./local_plugins"]


### PR DESCRIPTION
Use a class derived from namedtuple to store the actual unprocessed attribute names while still allowing for namedtuple like behaviour.

The new behaviour is more robust as attribute names that are not allowed for namedtuples can still be used without any change to the attribute name. Tuples have a `get` method that allows value access via attribute name.