### PR TITLE
Fix database connection error in costume loader plugin

### DIFF
--- a/plugins/costume_loader_pkg/__init__.py
+++ b/plugins/costume_loader_pkg/__init__.py
@@ -44,7 +44,7 @@ class CostumeLoader(QHAnaPluginBase):
         return COSTUME_LOADER_BLP
 
     def get_requirements(self) -> str:
-        return "mysql-connector-python==8.0.29"
+        return ""
 
 
 try:

--- a/plugins/costume_loader_pkg/__init__.py
+++ b/plugins/costume_loader_pkg/__init__.py
@@ -44,7 +44,7 @@ class CostumeLoader(QHAnaPluginBase):
         return COSTUME_LOADER_BLP
 
     def get_requirements(self) -> str:
-        return "mysql-connector-python~=8.0.26"
+        return "mysql-connector-python==8.0.29"
 
 
 try:

--- a/plugins/costume_loader_pkg/backend/database.py
+++ b/plugins/costume_loader_pkg/backend/database.py
@@ -24,7 +24,7 @@ class Database(Singleton):
 
     def open_with_params(self, host: str, user: str, password: str, database: str):
         engine: Engine = create_engine(
-            "mysql+pymysql://" + user + ":" + password + "@" + host + "/" + database
+            f"mysql+pymysql://{user}:{password}@{host}/{database}"
         )
 
         self.connected = True

--- a/plugins/costume_loader_pkg/backend/database.py
+++ b/plugins/costume_loader_pkg/backend/database.py
@@ -24,14 +24,7 @@ class Database(Singleton):
 
     def open_with_params(self, host: str, user: str, password: str, database: str):
         engine: Engine = create_engine(
-            "mysql+mysqlconnector://"
-            + user
-            + ":"
-            + password
-            + "@"
-            + host
-            + "/"
-            + database
+            "mysql+pymysql://" + user + ":" + password + "@" + host + "/" + database
         )
 
         self.connected = True


### PR DESCRIPTION
When using version 8.0.30 of the mysql-connector-python package to connect to a MariaDB database, the error "Character set 'utf8' unsupported" will occur. To prevent this, the version was pinned to 8.0.29.