### PR TITLE
Add celery default queue config and env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,10 @@ Currently the local file system is used as result store by default, meaning that
 This restriction also applies if the default sqlite database is used.
 
 For communication between server and worker containers, a redis or amqp broker need to be setup.
-Server and worker containers with the same plugin configuration need to use the same broker.
+Server and worker containers with the same plugin configuration need to use the same broker and queue name.
+Server and worker containers that use different sets of plugins need to use different brokers or the same broker but different queue names.
 The broker can be configured using the `BROKER_URL` and the `RESULT_BACKEND` environment variable.
+The environment variable `CELERY_QUEUE` can be used to set the queue name.
 
 The database to use can be configured using the `SQLALCHEMY_DATABASE_URI` environment variable.
 SQLAlchemy is used which supports SQLite, Postgres and MariaDB/MySQL databases given that the [correct drivers](https://docs.sqlalchemy.org/en/14/core/engines.html#supported-databases) are installed.

--- a/qhana_plugin_runner/__init__.py
+++ b/qhana_plugin_runner/__init__.py
@@ -92,11 +92,20 @@ def create_app(test_config: Optional[Dict[str, Any]] = None):
         # TODO load some config keys directly from env vars
 
         # load Redis URLs from env vars
-        if "BROKER_URL" in os.environ and "RESULT_BACKEND" in os.environ:
-            config["CELERY"] = {
-                "broker_url": os.environ["BROKER_URL"],
-                "result_backend": os.environ["RESULT_BACKEND"],
-            }
+        if "BROKER_URL" in environ:
+            celery_conf = config.get("CELERY", {})
+            celery_conf["broker_url"] = environ["BROKER_URL"]
+            config["CELERY"] = celery_conf
+
+        if "RESULT_BACKEND" in environ:
+            celery_conf = config.get("CELERY", {})
+            celery_conf["result_backend"] = environ["RESULT_BACKEND"]
+            config["CELERY"] = celery_conf
+
+        if "CELERY_QUEUE" in environ:
+            celery_conf = config.get("CELERY", {})
+            celery_conf["task_default_queue"] = environ["CELERY_QUEUE"]
+            config["CELERY"] = celery_conf
 
         if "PLUGIN_FOLDERS" in os.environ:
             config["PLUGIN_FOLDERS"] = [

--- a/qhana_plugin_runner/util/config/celery_config.py
+++ b/qhana_plugin_runner/util/config/celery_config.py
@@ -14,7 +14,7 @@
 
 from collections import ChainMap
 
-CELERY_PRODUCTION_CONFIG = {}
+CELERY_PRODUCTION_CONFIG = {"task_default_queue": "qhana_plugin_runner"}
 
 CELERY_DEBUG_CONFIG = ChainMap(
     {


### PR DESCRIPTION
The new option allows multiple plugin runners (and other celery apps) to share the same messaging infrastructure by defining different queues. Server and workers must have the same queue configuration!

TODO:

Add Issues to all docker compose repos using multiple plugin runners to use the new config (or update them directly)!

- [ ] qhana-docker
- [ ] quantil-docker