### PR TITLE
Update plugin types and data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2022-12-30
+
+### Changed
+
+- update of data and plugin types
+
+## [0.1.0] - 2021-08-03
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2022-12-30
+## [0.2.0] - 2022-12-30
 
 ### Changed
 

--- a/default-launch.json
+++ b/default-launch.json
@@ -2,7 +2,7 @@
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
+    "version": "0.3.0",
     "compounds": [
         {
             "name": "All",

--- a/default-launch.json
+++ b/default-launch.json
@@ -2,7 +2,7 @@
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.3.0",
+    "version": "0.2.0",
     "compounds": [
         {
             "name": "All",

--- a/docs/plugin-overview.rst
+++ b/docs/plugin-overview.rst
@@ -20,9 +20,9 @@ Plugin Overview
       - Mean/ Meadian/ Max/ Min Aggregators
       - aggregator
       - attributeDistancesUrl
-      - attribute-distances
+      - custom/attribute-distances
       - application/zip
-      - entity-distances
+      - custom/entity-distances
       - application/zip
 
     * - :rspan:`2` `Costume Loader <https://github.com/UST-QuAntiL/qhana-plugin-runner/tree/main/plugins/costume_loader_pkg>`_
@@ -31,14 +31,14 @@ Plugin Overview
       - :rspan:`2` 
       - :rspan:`2` 
       - :rspan:`2` 
-      - raw
+      - entity/list
       - application/json
   
-    * - attribute-metadata
+    * - entity/attribute-metadata
       - application/json
   
-    * - graphs
-      - application/json
+    * - custom/taxonomy-graphs
+      - application/zip
        
     * - `CSV Visualization <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/csv_visualization.py>`_
       - 
@@ -90,9 +90,9 @@ Plugin Overview
       - `Quantum Autoencoder <https://arxiv.org/abs/1612.02806>`_, `QNN1+2 (Circuit A+B) <https://arxiv.org/abs/1612.02806>`_, `QNN3 <http://arxiv.org/abs/2011.00027>`_, `General Two-Qubit-Gate <https://arxiv.org/abs/quant-ph/0308006>`_
       - dimensionality-reduction
       - 
-      - real-valued-entities
+      - custom/real-valued-entities
       - application/json
-      - real-valued-entities
+      - custom/real-valued-entities
       - application/json
   
     * - `JSON Visualization <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/json_visualization.py>`_
@@ -101,7 +101,7 @@ Plugin Overview
       - data
       - \*
       - application/json
-      - \*
+      - custom/hello-world-output
       - text/html
 
     * - `Manual Classification <https://github.com/UST-QuAntiL/qhana-plugin-runner/tree/main/plugins/manual_classification>`_
@@ -117,9 +117,9 @@ Plugin Overview
       - `Metric or nonmetric MDS <https://scikit-learn.org/stable/modules/generated/sklearn.manifold.MDS.html#sklearn.manifold.MDS>`_
       - dist-to-points
       - entityDistancesUrl
-      - entity-distances
+      - custom/entity-distances
       - application/json
-      - entity-points
+      - entity/vector
       - application/json
       
     * - `Minio Storage <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/minio-storage.py>`_
@@ -136,10 +136,41 @@ Plugin Overview
       - nisq-analyzer
       - 
       - 
-      - 
-      - 
-      - 
-      
+      - custom/nisq-analyzer-result
+      - application/json
+  
+    * - :rspan:`2` `One-Hot Encoding <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/one-hot_encoding.py>`_
+      - :rspan:`2` One-Hot Encoding
+      - :rspan:`2` encoding, one-hot
+      - entitiesUrl
+      - entity/list
+      - application/json
+      - :rspan:`2` entity/vector
+      - :rspan:`2` application/csv
+  
+    * - taxonomiesZipUrl
+      - graph/taxonomy
+      - application/zip
+  
+    * - entitiesMetadataUrl
+      - entity/attribute-metadata
+      - application/json  
+
+    * - :rspan:`2` `Principle Component Analysis <https://github.com/UST-QuAntiL/qhana-plugin-runner/tree/main/plugins/pca>`_
+      - :rspan:`2` normal, incremental, sparse and kernel PCA
+      - :rspan:`2` dimension-reduction
+      - :rspan:`2` entityPointsUrl
+      - :rspan:`2` entity/vector
+      - :rspan:`2` text/csv, application/json
+      - custom/plot
+      - text/html
+  
+    * - custom/pca-metadata
+      - application/json
+  
+    * - entity/vector
+      - text/csv
+  
     * - `Principle Component Analysis <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/pca.py>`_
       - `PCA <https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html>`_
       - dimension-reduction
@@ -153,70 +184,127 @@ Plugin Overview
       - `Quantum k-Means <https://arxiv.org/abs/1909.12183>`_ with custom adaptations for State-Preparation-Quantum-k-Means
       - points-to-clusters, k-means
       - entityPointsUrl
-      - entity-points
+      - entity/vector
       - application/json
-      - clusters
+      - custom/clusters
+      - application/json
+
+    * - :rspan:`1` `Quantum Kernel Estimation <https://github.com/UST-QuAntiL/qhana-plugin-runner/tree/main/plugins/quantum_kernel_estimation>`_
+      - :rspan:`1` Quantum Kernel Estimation with kernels from `Havlíček, V., Córcoles, A.D., Temme, K. et al. Supervised learning with quantum-enhanced feature spaces. Nature 567, 209–212 (2019). <https://doi.org/10.1038/s41586-019-0980-2>`
+      and `Suzuki, Y., Yano, H., Gao, Q. et al. Analysis and synthesis of feature map for kernel-based quantum classifier. Quantum Mach. Intell. 2, 9 (2020). <https://doi.org/10.1007/s42484-020-00020-y>`
+      - :rspan:`1` kernel, mapping
+      - entityPointsUrl1
+      - entity/vector
+      - application/json
+      - :rspan:`1` custom/kernel-matrix
+      - :rspan:`1` application/json
+    
+    * - entityPointsUrl2
+      - entity/vector
+      - application/json
+
+    * - :rspan:`1` `Qiskit Quantum Kernel Estimation <https://github.com/UST-QuAntiL/qhana-plugin-runner/tree/main/plugins/qiskit_quantum_kernel_estimation>`_
+      - :rspan:`1` Qiskit Quantum Kernel using qiskit's feature maps (ZFeatureMap, ZZFeatureMap, PauliFeatureMap) using the proposed kernel from `Havlíček, V., Córcoles, A.D., Temme, K. et al. Supervised learning with quantum-enhanced feature spaces. Nature 567, 209–212 (2019). <https://www.nature.com/articles/s41586-019-0980-2>`
+      - :rspan:`1` kernel, mapping
+      - entityPointsUrl1
+      - entity/vector
+      - application/json
+      - :rspan:`1` custom/kernel-matrix
+      - :rspan:`1` application/json
+    
+    * - entityPointsUrl2
+      - entity/vector
+      - application/json
+  
+    * - :rspan:`3` `Qiskit Simulator <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/qiskit_simulator.py>`_
+      - :rspan:`3` 
+      - :rspan:`3` circuit-executor, qc-simulator, qiskit, qasm, qasm-2
+      - :rspan:`1` circuit
+      - :rspan:`1` executable/circuit
+      - :rspan:`1` text/x-qasm
+      - entity/vector
+      - application/json
+  
+    * - entity/vector
+      - application/json
+  
+    * - :rspan:`1` executionOptions
+      - :rspan:`1` provenance/execution-options
+      - :rspan:`1` text/csv, application/json, application/X-lines+json
+      - provenance/trace
+      - application/json
+    
+    * - provenance/execution-options
       - application/json
       
     * - :rspan:`1` `Sym Max Mean Attribute Comparer <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/sym_max_mean.py>`_
       - :rspan:`1` 
       - :rspan:`1` attribute-similarity-calculation
       - entitiesUrl
-      - entities
+      - entity/list
       - application/json
-      - :rspan:`1` attribute-similarities
+      - :rspan:`1` custom/attribute-similarities
       - :rspan:`1` application/zip
   
     * - elementSimilaritiesUrl
-      - element-similarities
+      - custom/element-similarities
       - application/zip
   
     * - `Time Tanh Similarities <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/time_tanh.py>`_
       - 
       - similarity-calculation
       - entitiesUrl
-      - entities
+      - entity/list
       - application/json
-      - element-similarities
+      - custom/element-similarities
       - application/zip
       
     * - `Transformers (Similarity to Distance) <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/transformers.py>`_
       - Linear/ Exponential/ Gaussian/ Polynomial/ Square Inverse
       - sim-to-dist
       - attributeSimilaritiesUrl
-      - attribute-similarities
+      - custom/attribute-similarities
       - application/zip
-      - attribute-distances
+      - custom/attribute-distances
       - application/zip
       
     * - :rspan:`1` `Visualization <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/visualization.py>`_
       - :rspan:`1` 
       - :rspan:`1` visualization
       - entityPointsUrl
-      - entity-points
+      - entity/numeric
       - application/json
       - :rspan:`1` 
       - :rspan:`1` 
   
     * - clustersUrl
-      - clusters
+      - custom/clusters
       - application/json
 
+    * -  `Workflows <https://github.com/UST-QuAntiL/qhana-plugin-runner/tree/main/plugins/qiskit_quantum_kernel_estimation>`_
+      - 
+      - workflow, bpmn
+      - 
+      - 
+      - 
+      - 
+      - 
+  
     * - :rspan:`2` `Wu Palmer <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/wu_palmer.py>`_
       - :rspan:`2` Wu Palmer
       - :rspan:`2` similarity-calculation
       - entitiesUrl
-      - entities
+      - entity/list
       - application/json
-      - :rspan:`2` element-similarities
+      - :rspan:`2` custom/element-similarities
       - :rspan:`2` application/zip
     
     * - entitiesMetadataUrl
-      - attribute-metadata
+      - entity/attribute-metadata
       - application/json
 
     * - taxonomiesZipUrl
-      - taxonomy
+      - graph/taxonomy
       - application/zip
   
     * - :rspan:`1` `Zip Merger <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/zip_merger.py>`_

--- a/docs/plugin-overview.rst
+++ b/docs/plugin-overview.rst
@@ -170,15 +170,6 @@ Plugin Overview
   
     * - entity/vector
       - text/csv
-  
-    * - `Principle Component Analysis <https://github.com/UST-QuAntiL/qhana-plugin-runner/blob/main/plugins/pca.py>`_
-      - `PCA <https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html>`_
-      - dimension-reduction
-      - entityPointsUrl
-      - entity-points
-      - application/json
-      - principle-components
-      - application/json
 
     * - `Quantum k-Means <https://github.com/UST-QuAntiL/qhana-plugin-runner/tree/main/plugins/quantum_k_means>`_
       - `Quantum k-Means <https://arxiv.org/abs/1909.12183>`_ with custom adaptations for State-Preparation-Quantum-k-Means
@@ -190,8 +181,7 @@ Plugin Overview
       - application/json
 
     * - :rspan:`1` `Quantum Kernel Estimation <https://github.com/UST-QuAntiL/qhana-plugin-runner/tree/main/plugins/quantum_kernel_estimation>`_
-      - :rspan:`1` Quantum Kernel Estimation with kernels from `Havlíček, V., Córcoles, A.D., Temme, K. et al. Supervised learning with quantum-enhanced feature spaces. Nature 567, 209–212 (2019). <https://doi.org/10.1038/s41586-019-0980-2>`
-      and `Suzuki, Y., Yano, H., Gao, Q. et al. Analysis and synthesis of feature map for kernel-based quantum classifier. Quantum Mach. Intell. 2, 9 (2020). <https://doi.org/10.1007/s42484-020-00020-y>`
+      - :rspan:`1` Quantum Kernel Estimation with kernels from `Havlíček, V. et al. (2019) <https://doi.org/10.1038/s41586-019-0980-2>`_ and `Suzuki, Y. et al. (2020) <https://doi.org/10.1007/s42484-020-00020-y>`_
       - :rspan:`1` kernel, mapping
       - entityPointsUrl1
       - entity/vector
@@ -204,7 +194,7 @@ Plugin Overview
       - application/json
 
     * - :rspan:`1` `Qiskit Quantum Kernel Estimation <https://github.com/UST-QuAntiL/qhana-plugin-runner/tree/main/plugins/qiskit_quantum_kernel_estimation>`_
-      - :rspan:`1` Qiskit Quantum Kernel using qiskit's feature maps (ZFeatureMap, ZZFeatureMap, PauliFeatureMap) using the proposed kernel from `Havlíček, V., Córcoles, A.D., Temme, K. et al. Supervised learning with quantum-enhanced feature spaces. Nature 567, 209–212 (2019). <https://www.nature.com/articles/s41586-019-0980-2>`
+      - :rspan:`1` Qiskit Quantum Kernel using qiskit's feature maps (ZFeatureMap, ZZFeatureMap, PauliFeatureMap) using the proposed kernel from `Havlíček, V. et al. (2019). <https://www.nature.com/articles/s41586-019-0980-2>`_
       - :rspan:`1` kernel, mapping
       - entityPointsUrl1
       - entity/vector

--- a/plugins/aggregators.py
+++ b/plugins/aggregators.py
@@ -54,7 +54,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "distance-aggregator"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/aggregators.py
+++ b/plugins/aggregators.py
@@ -54,7 +54,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "distance-aggregator"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -129,7 +129,7 @@ class PluginsView(MethodView):
             name=Aggregator.instance.name,
             description=Aggregator.instance.description,
             version=Aggregator.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{AGGREGATOR_BLP.name}.CalcSimilarityView"),
                 ui_href=url_for(f"{AGGREGATOR_BLP.name}.MicroFrontend"),

--- a/plugins/aggregators.py
+++ b/plugins/aggregators.py
@@ -54,7 +54,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "distance-aggregator"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -92,7 +92,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     attribute_distances_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="attribute-distances",
+        data_input_type="custom/attribute-distances",
         data_content_types="application/zip",
         metadata={
             "label": "Attribute distances URL",
@@ -135,7 +135,7 @@ class PluginsView(MethodView):
                 ui_href=url_for(f"{AGGREGATOR_BLP.name}.MicroFrontend"),
                 data_input=[
                     InputDataMetadata(
-                        data_type="attribute-distances",
+                        data_type="custom/attribute-distances",
                         content_type=["application/zip"],
                         required=True,
                         parameter="attributeDistancesUrl",
@@ -143,7 +143,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="entity-distances",
+                        data_type="custom/entity-distances",
                         content_type=["application/zip"],
                         required=True,
                     )
@@ -342,7 +342,7 @@ def calculation_task(self, db_id: int) -> str:
             db_id,
             output,
             "entity_distances.json",
-            "entity-distances",
+            "custom/entity-distances",
             "application/json",
         )
 

--- a/plugins/costume_loader_pkg/__init__.py
+++ b/plugins/costume_loader_pkg/__init__.py
@@ -19,7 +19,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "costume-loader"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/costume_loader_pkg/__init__.py
+++ b/plugins/costume_loader_pkg/__init__.py
@@ -19,7 +19,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "costume-loader"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/costume_loader_pkg/__init__.py
+++ b/plugins/costume_loader_pkg/__init__.py
@@ -19,7 +19,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "costume-loader"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/costume_loader_pkg/routes.py
+++ b/plugins/costume_loader_pkg/routes.py
@@ -54,7 +54,7 @@ class PluginsView(MethodView):
                         required=True,
                     ),
                     DataMetadata(
-                        data_type="custom/taxonomy-graphs",
+                        data_type="graph/taxonomy",
                         content_type=["application/zip"],
                         required=True,
                     ),

--- a/plugins/costume_loader_pkg/routes.py
+++ b/plugins/costume_loader_pkg/routes.py
@@ -37,7 +37,7 @@ class PluginsView(MethodView):
             description=CostumeLoader.instance.description,
             name=CostumeLoader.instance.name,
             version=CostumeLoader.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{COSTUME_LOADER_BLP.name}.LoadingView"),
                 ui_href=url_for(f"{COSTUME_LOADER_BLP.name}.MicroFrontend"),

--- a/plugins/costume_loader_pkg/routes.py
+++ b/plugins/costume_loader_pkg/routes.py
@@ -44,17 +44,17 @@ class PluginsView(MethodView):
                 data_input=[],
                 data_output=[
                     DataMetadata(
-                        data_type="raw",
+                        data_type="entity/list",
                         content_type=["application/json"],
                         required=True,
                     ),
                     DataMetadata(
-                        data_type="attribute-metadata",
+                        data_type="entity/attribute-metadata",
                         content_type=["application/json"],
                         required=True,
                     ),
                     DataMetadata(
-                        data_type="graphs",
+                        data_type="custom/taxonomy-graphs",
                         content_type=["application/zip"],
                         required=True,
                     ),

--- a/plugins/costume_loader_pkg/tasks.py
+++ b/plugins/costume_loader_pkg/tasks.py
@@ -170,7 +170,7 @@ def loading_task(self, db_id: int) -> str:
         db_id,
         tmp_zip_file,
         "taxonomies.zip",
-        "graphs",
+        "graph/taxonomy",
         "application/zip",
     )
 

--- a/plugins/costume_loader_pkg/tasks.py
+++ b/plugins/costume_loader_pkg/tasks.py
@@ -93,7 +93,7 @@ def loading_task(self, db_id: int) -> str:
     with SpooledTemporaryFile(mode="w") as output:
         output.write(entities_json)
         STORE.persist_task_result(
-            db_id, output, "entities.json", "raw", "application/json"
+            db_id, output, "entities.json", "entity/list", "application/json"
         )
 
     #############################
@@ -146,7 +146,7 @@ def loading_task(self, db_id: int) -> str:
             db_id,
             output,
             "attribute_metadata.json",
-            "attribute-metadata",
+            "entity/attribute-metadata",
             "application/json",
         )
 

--- a/plugins/entity_filter.py
+++ b/plugins/entity_filter.py
@@ -61,7 +61,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "entity-filter"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 INFINITY = -1
@@ -176,7 +176,7 @@ class PluginsView(MethodView):
             description=EntityFilter.instance.description,
             name=EntityFilter.instance.name,
             version=EntityFilter.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{ENTITY_FILTER_BLP.name}.ProcessView"),
                 ui_href=url_for(f"{ENTITY_FILTER_BLP.name}.MicroFrontend"),

--- a/plugins/entity_filter.py
+++ b/plugins/entity_filter.py
@@ -61,7 +61,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "entity-filter"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 INFINITY = -1

--- a/plugins/entity_filter.py
+++ b/plugins/entity_filter.py
@@ -61,7 +61,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "entity-filter"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 INFINITY = -1

--- a/plugins/file_upload.py
+++ b/plugins/file_upload.py
@@ -48,7 +48,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "file-upload"
-__version__ = "v0.1.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/hello_worl_multi_step/__init__.py
+++ b/plugins/hello_worl_multi_step/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "hello-world-multi-step"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/hello_worl_multi_step/__init__.py
+++ b/plugins/hello_worl_multi_step/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "hello-world-multi-step"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/hello_worl_multi_step/__init__.py
+++ b/plugins/hello_worl_multi_step/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "hello-world-multi-step"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/hello_worl_multi_step/routes.py
+++ b/plugins/hello_worl_multi_step/routes.py
@@ -37,7 +37,7 @@ class PluginsView(MethodView):
             description=HelloWorldMultiStep.instance.description,
             name=HelloWorldMultiStep.instance.name,
             version=HelloWorldMultiStep.instance.version,
-            type=PluginType.complex,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{HELLO_MULTI_BLP.name}.ProcessView"),
                 ui_href=url_for(f"{HELLO_MULTI_BLP.name}.MicroFrontend"),

--- a/plugins/hello_world.py
+++ b/plugins/hello_world.py
@@ -108,7 +108,7 @@ class PluginsView(MethodView):
                 data_input=[],
                 data_output=[
                     DataMetadata(
-                        data_type="txt",
+                        data_type="custom/hello-world-output",
                         content_type=["text/plain"],
                         required=True,
                     )
@@ -239,7 +239,7 @@ def demo_task(self, db_id: int) -> str:
         with SpooledTemporaryFile(mode="w") as output:
             output.write(out_str)
             STORE.persist_task_result(
-                db_id, output, "out.txt", "hello-world-output", "text/plain"
+                db_id, output, "out.txt", "custom/hello-world-output", "text/plain"
             )
         return "result: " + repr(out_str)
     return "Empty input string, no output could be generated!"

--- a/plugins/hello_world.py
+++ b/plugins/hello_world.py
@@ -48,7 +48,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "hello-world"
-__version__ = "v0.1.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/hybrid_ae_pkg/__init__.py
+++ b/plugins/hybrid_ae_pkg/__init__.py
@@ -19,7 +19,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "hybrid-autoencoder"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/hybrid_ae_pkg/__init__.py
+++ b/plugins/hybrid_ae_pkg/__init__.py
@@ -19,7 +19,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "hybrid-autoencoder"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/hybrid_ae_pkg/__init__.py
+++ b/plugins/hybrid_ae_pkg/__init__.py
@@ -19,7 +19,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "hybrid-autoencoder"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/hybrid_ae_pkg/routes.py
+++ b/plugins/hybrid_ae_pkg/routes.py
@@ -43,14 +43,14 @@ class PluginsView(MethodView):
                 ui_href=url_for(f"{HA_BLP.name}.MicroFrontend"),
                 data_input=[
                     DataMetadata(
-                        data_type="real-valued-entities",
+                        data_type="custom/real-valued-entities",
                         content_type=["application/json"],
                         required=True,
                     )
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="real-valued-entities",
+                        data_type="custom/real-valued-entities",
                         content_type=["application/json"],
                         required=True,
                     )

--- a/plugins/hybrid_ae_pkg/routes.py
+++ b/plugins/hybrid_ae_pkg/routes.py
@@ -37,7 +37,7 @@ class PluginsView(MethodView):
             description=HybridAutoencoderPlugin.instance.description,
             name=HybridAutoencoderPlugin.instance.name,
             version=HybridAutoencoderPlugin.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{HA_BLP.name}.HybridAutoencoderPennylaneAPI"),
                 ui_href=url_for(f"{HA_BLP.name}.MicroFrontend"),

--- a/plugins/json_visualization.py
+++ b/plugins/json_visualization.py
@@ -50,7 +50,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "json-visualization"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/json_visualization.py
+++ b/plugins/json_visualization.py
@@ -50,7 +50,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "json-visualization"
-__version__ = "v0.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -112,7 +112,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="*",
+                        data_type="custom/hello-world-output",
                         content_type=["text/html"],
                         required=True,
                     )
@@ -236,7 +236,7 @@ def demo_task(self, db_id: int) -> str:
         with SpooledTemporaryFile(mode="w") as output:
             output.write(out_str)
             STORE.persist_task_result(
-                db_id, output, "out.txt", "hello-world-output", "text/plain"
+                db_id, output, "out.txt", "custom/hello-world-output", "text/plain"
             )
         return "result: " + repr(out_str)
     return "Empty input string, no output could be generated!"

--- a/plugins/manual_classification/__init__.py
+++ b/plugins/manual_classification/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "manual-classification"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 MANUAL_CLASSIFICATION_BLP = SecurityBlueprint(

--- a/plugins/manual_classification/__init__.py
+++ b/plugins/manual_classification/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "manual-classification"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 MANUAL_CLASSIFICATION_BLP = SecurityBlueprint(

--- a/plugins/manual_classification/__init__.py
+++ b/plugins/manual_classification/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "manual-classification"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 MANUAL_CLASSIFICATION_BLP = SecurityBlueprint(

--- a/plugins/manual_classification/routes.py
+++ b/plugins/manual_classification/routes.py
@@ -54,7 +54,7 @@ class PluginsView(MethodView):
             description=ManualClassification.instance.description,
             name=ManualClassification.instance.name,
             version=ManualClassification.instance.version,
-            type=PluginType.complex,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{MANUAL_CLASSIFICATION_BLP.name}.LoadView"),
                 ui_href=url_for(f"{MANUAL_CLASSIFICATION_BLP.name}.MicroFrontend"),

--- a/plugins/mds.py
+++ b/plugins/mds.py
@@ -54,7 +54,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "mds"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/mds.py
+++ b/plugins/mds.py
@@ -54,7 +54,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "mds"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -96,7 +96,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     entity_distances_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="entity-distances",
+        data_input_type="custom/entity-distances",
         data_content_types="application/json",
         metadata={
             "label": "Entity distances URL",
@@ -166,7 +166,7 @@ class PluginsView(MethodView):
                 ui_href=url_for(f"{MDS_BLP.name}.MicroFrontend"),
                 data_input=[
                     InputDataMetadata(
-                        data_type="entity-distances",
+                        data_type="custom/entity-distances",
                         content_type=["application/json"],
                         required=True,
                         parameter="entityDistancesUrl",
@@ -174,7 +174,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="entity-points",
+                        data_type="entity/vector",
                         content_type=["application/json"],
                         required=True,
                     )
@@ -377,7 +377,7 @@ def calculation_task(self, db_id: int) -> str:
             db_id,
             output,
             "entity_points.json",
-            "entity-points",
+            "entity/vector",
             "application/json",
         )
 

--- a/plugins/mds.py
+++ b/plugins/mds.py
@@ -54,7 +54,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "mds"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -160,7 +160,7 @@ class PluginsView(MethodView):
             description=MDS.instance.description,
             name=MDS.instance.name,
             version=MDS.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{MDS_BLP.name}.CalcView"),
                 ui_href=url_for(f"{MDS_BLP.name}.MicroFrontend"),

--- a/plugins/minio-storage.py
+++ b/plugins/minio-storage.py
@@ -128,7 +128,7 @@ class MinioStore(FileStore, name="minio"):
 
         if length < 0:
             # part size >5MiB must be set if the size is unknown
-            extra_args["part_size"] = 2 ** 25
+            extra_args["part_size"] = 2**25
 
         self._client.put_object(
             self._minio_bucket,

--- a/plugins/minio-storage.py
+++ b/plugins/minio-storage.py
@@ -26,7 +26,7 @@ from qhana_plugin_runner.db.models.tasks import TaskFile
 from qhana_plugin_runner.storage import FileStore
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase
 
-__version__ = "v0.1.0"
+__version__ = "v0.2.0"
 
 
 class HelloWorld(QHAnaPluginBase):
@@ -128,7 +128,7 @@ class MinioStore(FileStore, name="minio"):
 
         if length < 0:
             # part size >5MiB must be set if the size is unknown
-            extra_args["part_size"] = 2**25
+            extra_args["part_size"] = 2 ** 25
 
         self._client.put_object(
             self._minio_bucket,

--- a/plugins/nisq_analyzer.py
+++ b/plugins/nisq_analyzer.py
@@ -49,7 +49,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "nisq-analyzer"
-__version__ = "v0.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -140,7 +140,7 @@ class PluginsView(MethodView):
                 data_input=[],
                 data_output=[
                     DataMetadata(
-                        data_type="nisq-analyzer-result",
+                        data_type="custom/nisq-analyzer-result",
                         content_type=["application/json"],
                         required=True,
                     )
@@ -216,7 +216,7 @@ def store_results_task(self, db_id: int) -> str:
     with SpooledTemporaryFile(mode="w") as output:
         output.write(results_str)
         STORE.persist_task_result(
-            db_id, output, "nisq_analysis.json", "nisq-analyzer-result", "application/json"
+            db_id, output, "nisq_analysis.json", "custom/nisq-analyzer-result", "application/json"
         )
 
     return "result: " + repr(results_str)

--- a/plugins/one-hot_encoding.py
+++ b/plugins/one-hot_encoding.py
@@ -99,7 +99,7 @@ Improvements:
 
 
 _plugin_name = "one-hot encoding"
-__version__ = "v0.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -134,7 +134,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     entities_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="entities",
+        data_input_type="entity/list",
         data_content_types="application/json",
         metadata={
             "label": "Entities URL",
@@ -145,7 +145,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     entities_metadata_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="attribute-metadata",
+        data_input_type="entity/attribute-metadata",
         data_content_types="application/json",
         metadata={
             "label": "Entities Attribute Metadata URL",
@@ -156,7 +156,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     taxonomies_zip_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="taxonomy",
+        data_input_type="graph/taxonomy",
         data_content_types="application/zip",
         metadata={
             "label": "Taxonomies URL",
@@ -198,19 +198,19 @@ class PluginsView(MethodView):
                 ui_href=url_for(f"{ONEHOT_BLP.name}.MicroFrontend"),
                 data_input=[
                     InputDataMetadata(
-                        data_type="entities",
+                        data_type="entity/list",
                         content_type=["application/json"],
                         required=True,
                         parameter="entitiesUrl",
                     ),
                     InputDataMetadata(
-                        data_type="taxonomy",
+                        data_type="graph/taxonomy",
                         content_type=["application/zip"],
                         required=True,
                         parameter="taxonomiesZipUrl",
                     ),
                     InputDataMetadata(
-                        data_type="attribute-metadata",
+                        data_type="entity/attribute-metadata",
                         content_type=["application/json"],
                         required=True,
                         parameter="entitiesMetadataUrl",
@@ -218,7 +218,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="entity-points",
+                        data_type="entity/vector",
                         content_type=["application/csv"],
                         required=True,
                     )
@@ -488,7 +488,7 @@ def calculation_task(self, db_id: int) -> str:
             db_id,
             output,
             "one-hot-encoded_points.csv",
-            "entity-points",
+            "entity/vector",
             "text/csv",
         )
 

--- a/plugins/one-hot_encoding.py
+++ b/plugins/one-hot_encoding.py
@@ -99,7 +99,7 @@ Improvements:
 
 
 _plugin_name = "one-hot encoding"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -381,7 +381,9 @@ def get_ancestor_nodes(parent_node_dict, attribute, ancestor_nodes_dict) -> Set:
         return result
 
 
-def compute_ancestors_and_index_dict(entities, attributes, attribute_ref_targets, taxonomies) -> Tuple[List, List, int]:
+def compute_ancestors_and_index_dict(
+    entities, attributes, attribute_ref_targets, taxonomies
+) -> Tuple[List, List, int]:
     """
     Each entity owns certain attributes in a given taxonomy. This method computes the ancestors for each of the
     attributes in every given taxonomy.
@@ -420,14 +422,18 @@ def compute_ancestors_and_index_dict(entities, attributes, attribute_ref_targets
     return taxonomies_ancestors_list, attr_to_idx_dict_list, dim
 
 
-def prepare_stream_output(entities, attributes, taxonomies_ancestors_list, attr_to_idx_dict_list, dim):
+def prepare_stream_output(
+    entities, attributes, taxonomies_ancestors_list, attr_to_idx_dict_list, dim
+):
     """
     Transforms an entity into it's one-hot encoding and yields it.
     """
     for entity in entities:
         id = entity["ID"]
-        one_hot_encodings = np.zeros((dim, ))
-        for attribute, attr_to_idx_dict, taxonomies_ancestors in zip(attributes, attr_to_idx_dict_list, taxonomies_ancestors_list):
+        one_hot_encodings = np.zeros((dim,))
+        for attribute, attr_to_idx_dict, taxonomies_ancestors in zip(
+            attributes, attr_to_idx_dict_list, taxonomies_ancestors_list
+        ):
             values = entity[attribute]
 
             sub_attributes = set()
@@ -473,13 +479,23 @@ def calculation_task(self, db_id: int) -> str:
     # load data from file
     attributes = attributes.splitlines()
     # ref target is the name of the file containing the taxonomy
-    attribute_ref_targets = get_attribute_ref_target(entities_attribute_metadata_url, attributes)
+    attribute_ref_targets = get_attribute_ref_target(
+        entities_attribute_metadata_url, attributes
+    )
     # load taxonomies
     taxonomies = get_taxonomies_by_ref_target(attribute_ref_targets, taxonomies_zip_url)
 
     entities = open_url(entities_url).json()
-    taxonomies_ancestors_list, attr_to_idx_dict_list, dim = compute_ancestors_and_index_dict(entities, attributes, attribute_ref_targets, taxonomies)
-    entity_points = prepare_stream_output(entities, attributes, taxonomies_ancestors_list, attr_to_idx_dict_list, dim)
+    (
+        taxonomies_ancestors_list,
+        attr_to_idx_dict_list,
+        dim,
+    ) = compute_ancestors_and_index_dict(
+        entities, attributes, attribute_ref_targets, taxonomies
+    )
+    entity_points = prepare_stream_output(
+        entities, attributes, taxonomies_ancestors_list, attr_to_idx_dict_list, dim
+    )
     csv_attributes = ["ID", "href"] + [f"dim{d}" for d in range(dim)]
 
     with SpooledTemporaryFile(mode="w") as output:

--- a/plugins/pca/__init__.py
+++ b/plugins/pca/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "pca"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/pca/__init__.py
+++ b/plugins/pca/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "pca"
-__version__ = "v0.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/pca/routes.py
+++ b/plugins/pca/routes.py
@@ -74,12 +74,12 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="plot",
+                        data_type="custom/plot",
                         content_type=["text/html"],
                         required=False,
                     ),
                     DataMetadata(
-                        data_type="pca-metadata",
+                        data_type="custom/pca-metadata",
                         content_type=["application/json"],
                         required=True,
                     ),

--- a/plugins/pca/tasks.py
+++ b/plugins/pca/tasks.py
@@ -409,7 +409,7 @@ def save_outputs(
                 db_id,
                 output,
                 "plot.html",
-                "plot",
+                "custom/plot",
                 "text/html",
             )
     # save pca
@@ -419,7 +419,7 @@ def save_outputs(
             db_id,
             output,
             "pca_metadata.json",
-            "pca-metadata",
+            "custom/pca-metadata",
             "application/json",
         )
 
@@ -430,7 +430,7 @@ def save_outputs(
             db_id,
             output,
             "transformed_entity_points.csv",
-            "entity-points",
+            "entity/vector",
             "text/csv",
         )
 

--- a/plugins/qiskit_quantum_kernel_estimation/__init__.py
+++ b/plugins/qiskit_quantum_kernel_estimation/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "qiskit-quantum-kernel-estimation"
-__version__ = "v0.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/qiskit_quantum_kernel_estimation/__init__.py
+++ b/plugins/qiskit_quantum_kernel_estimation/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "qiskit-quantum-kernel-estimation"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/qiskit_quantum_kernel_estimation/routes.py
+++ b/plugins/qiskit_quantum_kernel_estimation/routes.py
@@ -81,7 +81,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="kernel-matrix",
+                        data_type="custom/kernel-matrix",
                         content_type=["application/json"],
                         required=True,
                     )

--- a/plugins/qiskit_quantum_kernel_estimation/tasks.py
+++ b/plugins/qiskit_quantum_kernel_estimation/tasks.py
@@ -162,7 +162,7 @@ def calculation_task(self, db_id: int) -> str:
             db_id,
             output,
             "kernel.json",
-            "kernel-matrix",
+            "custom/kernel-matrix",
             "application/json",
         )
 

--- a/plugins/qiskit_simulator.py
+++ b/plugins/qiskit_simulator.py
@@ -57,7 +57,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "qiskit-simulator"
-__version__ = "v0.2.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/qiskit_simulator.py
+++ b/plugins/qiskit_simulator.py
@@ -57,7 +57,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "qiskit-simulator"
-__version__ = "v1.0.0"
+__version__ = "v0.3.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/quantum_k_means/__init__.py
+++ b/plugins/quantum_k_means/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "quantum-k-means"
-__version__ = "v1.2.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -39,7 +39,7 @@ class QKMeans(QHAnaPluginBase):
         "Currently there are four implemented algorithms. Destructive interference and negative rotation are from [0], "
         "positive correlation is from [1] and state preparation is from a previous colleague.\n\n"
         "Source:\n"
-        '[0] [S. Khan and A. Awan and G. Vall-Llosera. K-Means Clustering on Noisy Intermediate Scale Quantum Computers.arXiv.](https://doi.org/10.48550/ARXIV.1909.12183)\n'
+        "[0] [S. Khan and A. Awan and G. Vall-Llosera. K-Means Clustering on Noisy Intermediate Scale Quantum Computers.arXiv.](https://doi.org/10.48550/ARXIV.1909.12183)\n"
         "[1] <https://towardsdatascience.com/quantum-machine-learning-distance-estimation-for-k-means-clustering-26bccfbfcc76>"
     )
     tags = ["points-to-clusters", "k-means"]

--- a/plugins/quantum_k_means/__init__.py
+++ b/plugins/quantum_k_means/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "quantum-k-means"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/quantum_k_means/__init__.py
+++ b/plugins/quantum_k_means/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "quantum-k-means"
-__version__ = "v1.1.0"
+__version__ = "v1.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/quantum_k_means/routes.py
+++ b/plugins/quantum_k_means/routes.py
@@ -55,7 +55,7 @@ class PluginsView(MethodView):
             description=QKMeans.instance.description,
             name=QKMeans.instance.name,
             version=QKMeans.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{QKMEANS_BLP.name}.CalcView"),
                 ui_href=url_for(f"{QKMEANS_BLP.name}.MicroFrontend"),

--- a/plugins/quantum_k_means/routes.py
+++ b/plugins/quantum_k_means/routes.py
@@ -72,7 +72,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="clusters",
+                        data_type="custom/clusters",
                         content_type=["application/json"],
                         required=True,
                     )

--- a/plugins/quantum_k_means/tasks.py
+++ b/plugins/quantum_k_means/tasks.py
@@ -152,7 +152,7 @@ def calculation_task(self, db_id: int) -> str:
             db_id,
             output,
             "clusters.json",
-            "clusters",
+            "custom/clusters",
             "application/json",
         )
 

--- a/plugins/quantum_kernel_estimation/__init__.py
+++ b/plugins/quantum_kernel_estimation/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "quantum-kernel-estimation"
-__version__ = "v0.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/quantum_kernel_estimation/__init__.py
+++ b/plugins/quantum_kernel_estimation/__init__.py
@@ -20,7 +20,7 @@ from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import plugin_identifier, QHAnaPluginBase
 
 _plugin_name = "quantum-kernel-estimation"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/quantum_kernel_estimation/routes.py
+++ b/plugins/quantum_kernel_estimation/routes.py
@@ -81,7 +81,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="kernel-matrix",
+                        data_type="custom/kernel-matrix",
                         content_type=["application/json"],
                         required=True,
                     )

--- a/plugins/quantum_kernel_estimation/tasks.py
+++ b/plugins/quantum_kernel_estimation/tasks.py
@@ -164,7 +164,7 @@ def calculation_task(self, db_id: int) -> str:
             db_id,
             output,
             "kernel.json",
-            "kernel-matrix",
+            "custom/kernel-matrix",
             "application/json",
         )
 

--- a/plugins/sym_max_mean.py
+++ b/plugins/sym_max_mean.py
@@ -59,7 +59,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "sym-max-mean"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -123,7 +123,7 @@ class PluginsView(MethodView):
             description=SymMaxMean.instance.description,
             name=SymMaxMean.instance.name,
             version=SymMaxMean.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{SYM_MAX_MEAN_BLP.name}.CalcSimilarityView"),
                 ui_href=url_for(f"{SYM_MAX_MEAN_BLP.name}.MicroFrontend"),

--- a/plugins/sym_max_mean.py
+++ b/plugins/sym_max_mean.py
@@ -59,7 +59,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "sym-max-mean"
-__version__ = "v1.0.0"
+__version__ = "v0.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/sym_max_mean.py
+++ b/plugins/sym_max_mean.py
@@ -59,7 +59,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "sym-max-mean"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -80,7 +80,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     entities_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="entities",
+        data_input_type="entity/list",
         data_content_types="application/json",
         metadata={
             "label": "Entities URL",
@@ -91,7 +91,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     element_similarities_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="element-similarities",
+        data_input_type="custom/element-similarities",
         data_content_types="application/zip",
         metadata={
             "label": "Element similarities URL",
@@ -129,13 +129,13 @@ class PluginsView(MethodView):
                 ui_href=url_for(f"{SYM_MAX_MEAN_BLP.name}.MicroFrontend"),
                 data_input=[
                     InputDataMetadata(
-                        data_type="entities",
+                        data_type="entity/list",
                         content_type=["application/json"],
                         required=True,
                         parameter="entitiesUrl",
                     ),
                     InputDataMetadata(
-                        data_type="element-similarities",
+                        data_type="custom/element-similarities",
                         content_type=["application/zip"],
                         required=True,
                         parameter="elementSimilaritiesUrl",
@@ -143,7 +143,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="attribute-similarities",
+                        data_type="custom/attribute-similarities",
                         content_type=["application/zip"],
                         required=True,
                     )
@@ -385,7 +385,7 @@ def calculation_task(self, db_id: int) -> str:
         db_id,
         tmp_zip_file,
         "sym_max_mean.zip",
-        "attribute_similarities",
+        "custom/attribute-similarities",
         "application/zip",
     )
 

--- a/plugins/time_tanh.py
+++ b/plugins/time_tanh.py
@@ -59,7 +59,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "time-tanh"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -80,7 +80,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     entities_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="entities",
+        data_input_type="entity/list",
         data_content_types="application/json",
         metadata={
             "label": "Entities URL",
@@ -127,7 +127,7 @@ class PluginsView(MethodView):
                 ui_href=url_for(f"{TIME_TANH_BLP.name}.MicroFrontend"),
                 data_input=[
                     InputDataMetadata(
-                        data_type="entities",
+                        data_type="entity/list",
                         content_type=["application/json"],
                         required=True,
                         parameter="entitiesUrl",
@@ -135,7 +135,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="element-similarities",
+                        data_type="custom/element-similarities",
                         content_type=["application/zip"],
                         required=True,
                     )
@@ -334,7 +334,7 @@ def calculation_task(self, db_id: int) -> str:
         db_id,
         tmp_zip_file,
         "time_tanh.zip",
-        "element-similarities",
+        "custom/element-similarities",
         "application/zip",
     )
 

--- a/plugins/time_tanh.py
+++ b/plugins/time_tanh.py
@@ -59,7 +59,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "time-tanh"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -121,7 +121,7 @@ class PluginsView(MethodView):
             description=TimeTanh.instance.description,
             name=TimeTanh.instance.name,
             version=TimeTanh.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{TIME_TANH_BLP.name}.CalcSimilarityView"),
                 ui_href=url_for(f"{TIME_TANH_BLP.name}.MicroFrontend"),

--- a/plugins/time_tanh.py
+++ b/plugins/time_tanh.py
@@ -59,7 +59,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "time-tanh"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/transformers.py
+++ b/plugins/transformers.py
@@ -57,7 +57,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "sim-to-dist-transformers"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -98,7 +98,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     attribute_similarities_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="attribute-similarities",
+        data_input_type="custom/attribute-similarities",
         data_content_types="application/zip",
         metadata={
             "label": "Attribute similarities URL",
@@ -150,7 +150,7 @@ class PluginsView(MethodView):
                 ui_href=url_for(f"{TRANSFORMERS_BLP.name}.MicroFrontend"),
                 data_input=[
                     InputDataMetadata(
-                        data_type="attribute-similarities",
+                        data_type="custom/attribute-similarities",
                         content_type=["application/zip"],
                         required=True,
                         parameter="attributeSimilaritiesUrl",
@@ -158,7 +158,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="attribute-distances",
+                        data_type="custom/attribute-distances",
                         content_type=["application/zip"],
                         required=True,
                     )
@@ -356,7 +356,7 @@ def calculation_task(self, db_id: int) -> str:
         db_id,
         tmp_zip_file,
         "attr_dist.zip",
-        "attribute_distances",
+        "custom/attribute-distances",
         "application/zip",
     )
 

--- a/plugins/transformers.py
+++ b/plugins/transformers.py
@@ -57,7 +57,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "sim-to-dist-transformers"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -144,7 +144,7 @@ class PluginsView(MethodView):
             description=Transformers.instance.description,
             name=Transformers.instance.name,
             version=Transformers.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{TRANSFORMERS_BLP.name}.CalcSimilarityView"),
                 ui_href=url_for(f"{TRANSFORMERS_BLP.name}.MicroFrontend"),

--- a/plugins/transformers.py
+++ b/plugins/transformers.py
@@ -57,7 +57,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "sim-to-dist-transformers"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/visualization.py
+++ b/plugins/visualization.py
@@ -51,7 +51,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "visualization"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -82,7 +82,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     entity_points_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="entity-points",
+        data_input_type="entity/numeric",
         data_content_types="application/json",
         metadata={
             "label": "Entity points URL",
@@ -93,7 +93,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     clusters_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="clusters",
+        data_input_type="custom/clusters",
         data_content_types="application/json",
         metadata={
             "label": "Clusters URL",
@@ -126,13 +126,13 @@ class PluginsView(MethodView):
                 ui_href=url_for(f"{VIS_BLP.name}.MicroFrontend"),
                 data_input=[
                     InputDataMetadata(
-                        data_type="entity-points",
+                        data_type="entity/numeric",
                         content_type=["application/json"],
                         required=True,
                         parameter="entityPointsUrl",
                     ),
                     InputDataMetadata(
-                        data_type="clusters",
+                        data_type="custom/clusters",
                         content_type=["application/json"],
                         required=True,
                         parameter="clustersUrl",

--- a/plugins/visualization.py
+++ b/plugins/visualization.py
@@ -51,7 +51,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "visualization"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -82,7 +82,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     entity_points_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="entity/numeric",
+        data_input_type="entity/*",
         data_content_types="application/json",
         metadata={
             "label": "Entity points URL",
@@ -126,7 +126,7 @@ class PluginsView(MethodView):
                 ui_href=url_for(f"{VIS_BLP.name}.MicroFrontend"),
                 data_input=[
                     InputDataMetadata(
-                        data_type="entity/numeric",
+                        data_type="entity/*",
                         content_type=["application/json"],
                         required=True,
                         parameter="entityPointsUrl",

--- a/plugins/visualization.py
+++ b/plugins/visualization.py
@@ -51,7 +51,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "visualization"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -120,7 +120,7 @@ class PluginsView(MethodView):
             description=VIS.instance.description,
             name=VIS.instance.name,
             version=VIS.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{VIS_BLP.name}.CalcView"),
                 ui_href=url_for(f"{VIS_BLP.name}.MicroFrontend"),

--- a/plugins/wu_palmer.py
+++ b/plugins/wu_palmer.py
@@ -60,7 +60,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "wu-palmer"
-__version__ = "v1.0.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 

--- a/plugins/wu_palmer.py
+++ b/plugins/wu_palmer.py
@@ -60,7 +60,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "wu-palmer"
-__version__ = "v1.1.0"
+__version__ = "v1.0.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -81,7 +81,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     entities_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="entities",
+        data_input_type="entity/list",
         data_content_types="application/json",
         metadata={
             "label": "Entities URL",
@@ -92,7 +92,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     entities_metadata_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="attribute-metadata",
+        data_input_type="entity/attribute-metadata",
         data_content_types="application/json",
         metadata={
             "label": "Entities Attribute Metadata URL",
@@ -103,7 +103,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     taxonomies_zip_url = FileUrl(
         required=True,
         allow_none=False,
-        data_input_type="taxonomy",
+        data_input_type="graph/taxonomy",
         data_content_types="application/zip",
         metadata={
             "label": "Taxonomies URL",
@@ -153,19 +153,19 @@ class PluginsView(MethodView):
                 ui_href=url_for(f"{WU_PALMER_BLP.name}.MicroFrontend"),
                 data_input=[
                     InputDataMetadata(
-                        data_type="entities",
+                        data_type="entity/list",
                         content_type=["application/json"],
                         required=True,
                         parameter="entitiesUrl",
                     ),
                     InputDataMetadata(
-                        data_type="attribute-metadata",
+                        data_type="entity/attribute-metadata",
                         content_type=["application/json"],
                         required=True,
                         parameter="entitiesMetadataUrl",
                     ),
                     InputDataMetadata(
-                        data_type="taxonomy",
+                        data_type="graph/taxonomy",
                         content_type=["application/zip"],
                         required=True,
                         parameter="taxonomiesZipUrl",
@@ -173,7 +173,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="element-similarities",
+                        data_type="custom/element-similarities",
                         content_type=["application/zip"],
                         required=True,
                     )
@@ -530,7 +530,7 @@ def calculation_task(self, db_id: int) -> str:
         db_id,
         tmp_zip_file,
         "wu_palmer.zip",
-        "element-similarities",
+        "custom/element-similarities",
         "application/zip",
     )
 

--- a/plugins/wu_palmer.py
+++ b/plugins/wu_palmer.py
@@ -60,7 +60,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "wu-palmer"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -147,7 +147,7 @@ class PluginsView(MethodView):
             description=WuPalmer.instance.description,
             name=WuPalmer.instance.name,
             version=WuPalmer.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{WU_PALMER_BLP.name}.CalcSimilarityView"),
                 ui_href=url_for(f"{WU_PALMER_BLP.name}.MicroFrontend"),

--- a/plugins/zip_merger.py
+++ b/plugins/zip_merger.py
@@ -53,7 +53,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "zip-merger"
-__version__ = "v1.1.0"
+__version__ = "v0.2.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -114,13 +114,13 @@ class PluginsView(MethodView):
                 ui_href=url_for(f"{ZIP_MERGER_BLP.name}.MicroFrontend"),
                 data_input=[
                     InputDataMetadata(
-                        data_type="any",
+                        data_type="*",
                         content_type=["application/zip"],
                         required=True,
                         parameter="zip1Url",
                     ),
                     InputDataMetadata(
-                        data_type="any",
+                        data_type="*",
                         content_type=["application/zip"],
                         required=True,
                         parameter="zip2Url",
@@ -128,7 +128,7 @@ class PluginsView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="any", content_type=["application/zip"], required=True
+                        data_type="*", content_type=["application/zip"], required=True
                     )
                 ],
             ),
@@ -267,7 +267,7 @@ def calculation_task(self, db_id: int) -> str:
         db_id,
         tmp_zip_file,
         "merged.zip",
-        "any",
+        "*",
         "application/zip",
     )
 

--- a/plugins/zip_merger.py
+++ b/plugins/zip_merger.py
@@ -53,7 +53,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
 _plugin_name = "zip-merger"
-__version__ = "v0.1.0"
+__version__ = "v1.1.0"
 _identifier = plugin_identifier(_plugin_name, __version__)
 
 
@@ -108,7 +108,7 @@ class PluginsView(MethodView):
             description=ZipMerger.instance.description,
             name=ZipMerger.instance.name,
             version=ZipMerger.instance.version,
-            type=PluginType.simple,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(f"{ZIP_MERGER_BLP.name}.CalcSimilarityView"),
                 ui_href=url_for(f"{ZIP_MERGER_BLP.name}.MicroFrontend"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qhana_plugin_runner"
-version = "0.1.0"
+version = "0.2.0"
 description = "The runner for QHAna plugins."
 authors = ["QHAna authors"]
 license = "Apache-2.0"

--- a/qhana_plugin_runner/api/plugin_schemas.py
+++ b/qhana_plugin_runner/api/plugin_schemas.py
@@ -27,11 +27,7 @@ from qhana_plugin_runner.api.util import MaBaseSchema
 
 
 class PluginType(Enum):
-    """Type of the plugin.
-
-    Deprecation Warning:
-        "simple" and "complex" are deprecated and should be replaced with "processing"!
-    """
+    """Type of the plugin."""
 
     processing = "processing"
     visualization = "visualization"

--- a/qhana_plugin_runner/api/plugin_schemas.py
+++ b/qhana_plugin_runner/api/plugin_schemas.py
@@ -33,8 +33,6 @@ class PluginType(Enum):
         "simple" and "complex" are deprecated and should be replaced with "processing"!
     """
 
-    simple = "simple"
-    complex = "complex"
     processing = "processing"
     visualization = "visualization"
     conversion = "conversion"


### PR DESCRIPTION
- [x] plugin types
- [x] data types

Uncertain about some data types: 

- costume loader: `entity/list` statt raw and `custom/taxonomy-graphs` statt `graphs `(output)?
- zip merger: `custom/any` statt `any`?
- visualization: `entity/numeric` statt `entity-points` (input)?
- one-hot encoding: `entity/vector` statt `entity-points` (output)?
- json/csv visualization, file upload: change from `*`?
- custom types for wu palmer, time tanh, sym max mean, transformers, aggregators, mds