### PR TITLE
Apply reverse proxy fix, fix authentication in JSON virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ This defaults to `local_filesystem`.
 When a worker (or plugin in the worker) tries to generate a URL with `flask.url_for` and `_external=True`, it can fail with the error `Application was not able to create a URL adapter for request independent URL generation. You might be able to fix this by setting the SERVER_NAME config variable.`.
 You can set the environment variable `SERVER_NAME` for the worker container and the value will be set in the flask configuration.
 
+If it runs behind a reverse proxy, set `REVERSE_PROXY_COUNT` to the number of trusted reverse proxies (e.g. 1).
+
 The docker container includes a [proxy]("https://github.com/UST-QuAntiL/docker-localhost-proxy") to redirect requests to the host machine.
 To configure the ports that should be redirected set the environment variable `LOCALHOST_PROXY_PORTS` to e.g. `:1234 :2345`.
 

--- a/plugins/json_visualization_templates/json_visualization.html
+++ b/plugins/json_visualization_templates/json_visualization.html
@@ -64,7 +64,7 @@
             const url = getUrl()
 
             if (checkUrl(url)) {
-                fetch(url)
+                fetch(url, { "credentials": "include" })
                     .then((response) => response.text())
                     .then((json_str) => addJsonToPreview(json_str))
             }

--- a/qhana_plugin_runner/__init__.py
+++ b/qhana_plugin_runner/__init__.py
@@ -43,6 +43,7 @@ from .util.config import DebugConfig, ProductionConfig
 from .util.jinja_helpers import register_helpers
 from .util.plugins import register_plugins
 from .util.request_helpers import register_additional_schemas
+from .util.reverse_proxy_fix import apply_reverse_proxy_fix
 from .util.templates import register_templates
 
 # change this to change tha flask app name and the config env var prefix
@@ -133,6 +134,10 @@ def create_app(test_config: Optional[Dict[str, Any]] = None):
 
         if "PLUGIN_REGISTRY_URL" in os.environ:
             config["PLUGIN_REGISTRY_URL"] = os.environ["PLUGIN_REGISTRY_URL"]
+
+        if "REVERSE_PROXY_COUNT" in os.environ:
+            config["REVERSE_PROXY_COUNT"] = int(os.environ["REVERSE_PROXY_COUNT"])
+            apply_reverse_proxy_fix(app)
     else:
         # load the test config if passed in
         config.from_mapping(test_config)


### PR DESCRIPTION
This PR applies the reverse proxy fix to allow running the plugin runner behind a reverse proxy. Also the JSON virtualization plugin now sends credentials with the request to the backend to allow the use authentication.