### PR TITLE
Fix 'type "blob" does not exist' error in Postgres databases

### DIFF
--- a/migrations/versions/a09e03db46a1_add_virtual_plugins.py
+++ b/migrations/versions/a09e03db46a1_add_virtual_plugins.py
@@ -21,7 +21,7 @@ def upgrade():
         "DataBlob",
         sa.Column("id", sa.INTEGER(), nullable=False),
         sa.Column("plugin_id", sa.String(length=550), nullable=False),
-        sa.Column("value", sa.BLOB(), nullable=False),
+        sa.Column("value", sa.LargeBinary(), nullable=False),
         sa.PrimaryKeyConstraint("id", "plugin_id", name=op.f("pk_DataBlob")),
     )
     op.create_table(

--- a/qhana_plugin_runner/db/models/virtual_plugins.py
+++ b/qhana_plugin_runner/db/models/virtual_plugins.py
@@ -266,4 +266,4 @@ class DataBlob:
 
     id: Mapped[int] = mapped_column(sql.INTEGER(), primary_key=True, init=False)
     plugin_id: Mapped[str] = mapped_column(sql.String(550), primary_key=True)
-    value: Mapped[bytes] = mapped_column(sql.BLOB())
+    value: Mapped[bytes] = mapped_column(sql.LargeBinary())


### PR DESCRIPTION
This PR fixes the 'type "blob" does not exist' error when using a Postgres database. I changed the specific column type "BLOB" to the more generic "LargeBinary". I didn't create a new migration, because it would still crash when trying to create a "BLOB" column during the "add virtual plugins" migration.