### PR TITLE
fix: form-submit filename instead of file object

### DIFF
--- a/qhana_plugin_runner/static/microfrontend.js
+++ b/qhana_plugin_runner/static/microfrontend.js
@@ -404,7 +404,7 @@ function onFormSubmit(event, dataInputs, privateInputs) {
             }
             if (entry instanceof File) {
                 // add filename instead of file object
-                processedFormData.append(key, entry.name);
+                processedFormData.append(key, `Uploaded file: ${entry.name}`);
                 return;
             }
             // add all other values unchanged

--- a/qhana_plugin_runner/static/microfrontend.js
+++ b/qhana_plugin_runner/static/microfrontend.js
@@ -402,6 +402,11 @@ function onFormSubmit(event, dataInputs, privateInputs) {
                 processedFormData.append(key, '***');
                 return;
             }
+            if (entry instanceof File) {
+                // add filename instead of file object
+                processedFormData.append(key, entry.name);
+                return;
+            }
             // add all other values unchanged
             processedFormData.append(key, entry);
             // add data inputs to extra list


### PR DESCRIPTION
The `microfrontend.js` passes on form data as string when a plugin is submitted. When the form data contains a file object (like for the file-upload plugin), this results in the string `[object File]`. This PR sets the `processedFormData` entry for file objects to the filename.

This change affects for example the timeline inputs view in the qhana-ui:
Before:
![image](https://github.com/UST-QuAntiL/qhana-plugin-runner/assets/33042539/27b5f26a-40b3-4d22-8220-4ae8caaa0e9d)
Fixed:
![image](https://github.com/UST-QuAntiL/qhana-plugin-runner/assets/33042539/71e3816a-9f7e-4b44-970e-13d4e3c90422)

