### PR TITLE
Docker: Add missing poetry export plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ADD https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/Ca
 ADD https://raw.githubusercontent.com/UST-QuAntiL/docker-localhost-proxy/v0.3/start_proxy.sh start_proxy.sh
 RUN chmod +x start_proxy.sh
 
-RUN python -m pip install poetry gunicorn
+RUN python -m pip install poetry poetry-plugin-export gunicorn
 
 COPY --chown=gunicorn . /app
 


### PR DESCRIPTION
The export functionality is not default anymore in Poetry>=2.0 causing the build of the Dockerfile to fail.

See: https://python-poetry.org/docs/cli/#export

Added the missing plugin via pip install in the Dockerfile 