### PR TITLE
Improve handling of None values in MUSE plugins

### DIFF
--- a/stable_plugins/classical_ml/data_preparation/aggregators.py
+++ b/stable_plugins/classical_ml/data_preparation/aggregators.py
@@ -116,7 +116,10 @@ class InputParametersSchema(FrontendFormBaseSchema):
         required=True,
         metadata={
             "label": "Missing data handling",
-            "description": "Defines how a missing attribute distance should be handled.",
+            "description": """Defines how a missing attribute distance should be handled.
+- ignore: null values are removed and only the not null values are used for the aggregation
+- mean: null values are replaced by the mean distance of the respective attribute
+- max: null values are replaced by the maximum distance of the respective attribute""",
             "input_type": "select",
         },
     )

--- a/stable_plugins/classical_ml/data_preparation/aggregators.py
+++ b/stable_plugins/classical_ml/data_preparation/aggregators.py
@@ -301,6 +301,10 @@ def calculation_task(self, db_id: int) -> str:
         attr_name = file_name[:-5]
 
         loaded_distances = json.load(file)
+        # FIXME: handle all distances being None
+        distances_without_none: list[float] = [
+            dist["distance"] for dist in loaded_distances if dist["distance"] is not None
+        ]
 
         if missing_data_handling == MissingDataHandling.ignore:
             # removes elements with None distance
@@ -308,41 +312,17 @@ def calculation_task(self, db_id: int) -> str:
                 dist for dist in loaded_distances if dist["distance"] is not None
             ]  # FIXME: handle all distances being None
         elif missing_data_handling == MissingDataHandling.mean:
-            distances = [
-                dist["distance"]
-                for dist in loaded_distances
-                if dist["distance"] is not None
-            ]  # FIXME: handle all distances being None
-            mean_distance = sum(distances) / len(distances)
-
+            mean_distance = sum(distances_without_none) / len(distances_without_none)
             # replaces None distances with the mean distance
-            new_list = []
-
             for dist in loaded_distances:
                 if dist["distance"] is None:
                     dist["distance"] = mean_distance
-
-                new_list.append(dist)
-
-            loaded_distances = new_list
         elif missing_data_handling == MissingDataHandling.max:
-            distances = [
-                dist["distance"]
-                for dist in loaded_distances
-                if dist["distance"] is not None
-            ]  # FIXME: handle all distances being None
-            max_distance = max(distances)
-
+            max_distance = max(distances_without_none)
             # replaces None distances with the max distance
-            new_list = []
-
             for dist in loaded_distances:
                 if dist["distance"] is None:
                     dist["distance"] = max_distance
-
-                new_list.append(dist)
-
-            loaded_distances = new_list
         else:
             raise NotImplementedError(
                 f"Unknown missing_data_handling '{missing_data_handling}'"

--- a/stable_plugins/classical_ml/data_preparation/sym_max_mean.py
+++ b/stable_plugins/classical_ml/data_preparation/sym_max_mean.py
@@ -261,7 +261,7 @@ def _get_sim(elem_sims: Dict, val1, val2) -> float:
     elif (val2, val1) in elem_sims:
         return elem_sims[(val2, val1)]["similarity"]
     else:
-        return 0.0
+        return 0.0  # handles missing elements in lists
 
 
 @CELERY.task(name=f"{SymMaxMean.instance.identifier}.calculation_task", bind=True)

--- a/stable_plugins/classical_ml/data_preparation/transformers.py
+++ b/stable_plugins/classical_ml/data_preparation/transformers.py
@@ -314,7 +314,9 @@ def calculation_task(self, db_id: int) -> str:
             sim = sim_entity["similarity"]
             dist = None
 
-            if transformer == TransformersEnum.linear_inverse:
+            if sim is None:
+                dist = None
+            elif transformer == TransformersEnum.linear_inverse:
                 dist = 1.0 - sim
             elif transformer == TransformersEnum.exponential_inverse:
                 dist = math.exp(-sim)


### PR DESCRIPTION
- similarities to distances converter
  - a None similarity will result in a None distance
- aggregator
  - the user can choose how to handle None attribute values
  - ignore: None values are removed and only the not None values are used for the aggregation
  - mean: None values are replaced by the mean distance of the respective attribute
  - max: None values are replaced by the maximum distance of the respective attribute