### PR TITLE
workflow plugin refactor

### DIFF
--- a/stable_plugins/workflow/workflows/clients/camunda_client.py
+++ b/stable_plugins/workflow/workflows/clients/camunda_client.py
@@ -3,6 +3,7 @@ import logging
 import re
 from typing import List, Mapping, Optional, Sequence
 from xml.etree import ElementTree
+from typing import TypedDict, Dict, Literal, Any, Generic, TypeVar
 
 import requests
 from requests.exceptions import HTTPError
@@ -14,6 +15,14 @@ from ..datatypes.camunda_datatypes import ExternalTask, HumanTask, WorkflowIncid
 from ..exceptions import WorkflowDeploymentError
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class CamundaVariable(TypedDict, Generic[T]):
+    value: T
+    type: Literal["Object", "Array", "String", "Number", "Boolean"]
+    valueInfo: Dict[str, str]
 
 
 def extract_id_and_name(bpmn_url: str):
@@ -189,11 +198,12 @@ class CamundaClient:
         response.raise_for_status()
         return response.json()["count"]
 
-    def get_external_tasks(self, limit: Optional[int] = None):
+    def get_external_tasks(self, limit: Optional[int] = None, topic: Optional[str] = None):
         """Get unlocked external tasks from the task queue.
 
         Args:
             limit (Optional[int], optional): limit the number of unlocked external tasks to fetch. If set at most limit external tasks will be returned. Defaults to None.
+            topic (Optional[str], optional): limit the tasks to a specific topic.
 
         Raises:
             ValueError: the limits have illegal values
@@ -203,6 +213,8 @@ class CamundaClient:
             if limit < 1:
                 raise ValueError("The limit must not be smaller than 1!")
             params["maxResults"] = str(limit)
+        if topic:
+            params["topicName"] = topic
         response = requests.get(
             f"{self.base_url}/external-task",
             params=params,
@@ -395,7 +407,7 @@ class CamundaClient:
 
         return {k: v for k, v in instance_variables.items() if k in form_variables}
 
-    def get_task_local_variables(self, external_task_execution_id: str):
+    def get_task_local_variables(self, external_task_execution_id: str) -> Dict[str, CamundaVariable[Any]]:
         """
         Gets all local variables of an external task
         :param external_task_execution_id: The execution_id of the external task
@@ -408,7 +420,7 @@ class CamundaClient:
         response.raise_for_status()
         return response.json()
 
-    def get_global_variable(self, name: str, process_instance_id: str):
+    def get_global_variable(self, name: str, process_instance_id: str) -> Dict[str, CamundaVariable[Any]]:
         """
         Retrieves the global variable for a given name
         :param name: The global variable name

--- a/stable_plugins/workflow/workflows/config.py
+++ b/stable_plugins/workflow/workflows/config.py
@@ -19,11 +19,11 @@ class FormInputConfig(TypedDict):
 
 class WorkflowConfig(TypedDict):
     workflow_error_prefix: str
-    plugin_task_topic: str
-    plugin_variable: str
     legacy_plugin_task_topic_prefix: str
-    step_task_topic: str
     legacy_step_topic_prefix: str
+    disable_legacy_support: bool
+    qhana_task_topic: str
+    plugin_variable: str
     step_variable: str
     task_input_variable_prefix: str
     task_output_variable_prefix: str
@@ -109,10 +109,10 @@ def get_config(app: Flask | None = None) -> WorkflowPluginConfig:
 
     workflow_conf: WorkflowConfig = {
         "workflow_error_prefix": "qhana",
+        "disable_legacy_support": False,
         "legacy_plugin_task_topic_prefix": "plugin",
         "legacy_step_topic_prefix": "plugin-step",
-        "plugin_task_topic": "qhana-plugin-task",
-        "step_task_topic": "qhana-plugin-step-task",
+        "qhana_task_topic": "qhana-task",
         "plugin_variable": "qhana-plugin",
         "step_variable": "qhana-plugin-step",
         "task_output_variable_prefix": "qoutput",

--- a/stable_plugins/workflow/workflows/config.py
+++ b/stable_plugins/workflow/workflows/config.py
@@ -24,6 +24,7 @@ class WorkflowConfig(TypedDict):
     disable_legacy_support: bool
     qhana_task_topic: str
     plugin_variable: str
+    plugin_version_variable: str
     step_variable: str
     task_input_variable_prefix: str
     task_output_variable_prefix: str
@@ -113,8 +114,9 @@ def get_config(app: Flask | None = None) -> WorkflowPluginConfig:
         "legacy_plugin_task_topic_prefix": "plugin",
         "legacy_step_topic_prefix": "plugin-step",
         "qhana_task_topic": "qhana-task",
-        "plugin_variable": "qhana-plugin",
-        "step_variable": "qhana-plugin-step",
+        "plugin_variable": "qhanaPlugin",
+        "plugin_version_variable": "qhanaPluginVersion",
+        "step_variable": "qhanaPluginStep",
         "task_output_variable_prefix": "qoutput",
         "task_input_variable_prefix": "qinput",
         "prefix_separator": ".",

--- a/stable_plugins/workflow/workflows/watchers/external/external_task_watcher.py
+++ b/stable_plugins/workflow/workflows/watchers/external/external_task_watcher.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, cast
 
 from celery.utils.log import get_task_logger
 from requests.exceptions import (
@@ -10,9 +10,9 @@ from requests.exceptions import (
 
 from qhana_plugin_runner.celery import CELERY
 
-from .qhana_instance_watcher import qhana_instance_watcher, qhana_step_watcher
 from ... import DeployWorkflow
 from ...clients.camunda_client import CamundaClient
+from ...config import WorkflowConfig
 from ...datatypes.camunda_datatypes import ExternalTask
 from ...exceptions import (
     BadInputsError,
@@ -24,13 +24,18 @@ from ...exceptions import (
     ResultError,
     WorkflowTaskError,
 )
+from .qhana_instance_watcher import (
+    QHAnaStepData,
+    qhana_instance_watcher,
+    qhana_step_watcher,
+)
 
 config = DeployWorkflow.instance.config
 
 TASK_LOGGER = get_task_logger(__name__)
 
 
-def execute_task(external_task: ExternalTask, camunda_client: CamundaClient, watcher):
+def execute_task_legacy(external_task: ExternalTask, camunda_client: CamundaClient, watcher):
     if external_task.execution_id is None:
         raise BadTaskDefinitionError(
             message=f"External task {external_task} has no execution id!"
@@ -51,6 +56,68 @@ def execute_task(external_task: ExternalTask, camunda_client: CamundaClient, wat
     instance_task.apply_async()
 
 
+def execute_task(external_task: ExternalTask, camunda_client: CamundaClient, config: WorkflowConfig):
+    if external_task.execution_id is None:
+        raise BadTaskDefinitionError(
+            message=f"External task {external_task} has no execution id!"
+        )
+    variables = camunda_client.get_task_local_variables(external_task.id)
+    qhana_vars = {config["plugin_variable"], config["step_variable"]} - variables.keys()
+    if len(qhana_vars) > 1:
+        raise BadTaskDefinitionError(
+            message=f"External task {external_task} has conflicting QHAna variables {config['plugin_variable']} and {config['step_variable']}!"
+        )
+    if not qhana_vars:
+        raise BadTaskDefinitionError(
+            message=f"External task {external_task} has no QHAna variables! Expected either {config['plugin_variable']} or {config['step_variable']}."
+        )
+
+    is_plugin_task = config["plugin_variable"] in variables
+    qhana_var_value: str | dict | QHAnaStepData
+
+    if is_plugin_task:
+        qhana_var_value = variables[config["plugin_variable"]]["value"]
+        if not isinstance(qhana_var_value, str):
+            raise BadTaskDefinitionError(
+                message=f"The {config['plugin_variable']} variable of external task {external_task} has an invalid value of '{qhana_var_value}', expected a string."
+            )
+    else:
+        qhana_var_value = variables[config["step_variable"]]["value"]
+        if not isinstance(qhana_var_value, dict):
+            raise BadTaskDefinitionError(
+                message=f"The {config['step_variable']} variable of external task {external_task} has an invalid value of '{qhana_var_value}', expected a dict."
+            )
+        if not all(isinstance(qhana_var_value.get(key), a) for key, a in QHAnaStepData.__annotations__.items()):
+            raise BadTaskDefinitionError(
+                message=f"The {config['step_variable']} variable of external task {external_task} has an invalid value of '{qhana_var_value}', expected a dict of with the form of {QHAnaStepData.__annotations__}."
+            )
+        qhana_var_value = cast(QHAnaStepData, qhana_var_value)
+
+    # Lock task for usage and to block other watchers from access
+    camunda_client.lock(external_task.id)
+
+    if is_plugin_task:
+        instance_task = qhana_instance_watcher.s(
+            topic_name=external_task.topic_name,
+            external_task_id=external_task.id,
+            execution_id=external_task.execution_id,
+            process_instance_id=external_task.process_instance_id,
+            plugin=qhana_var_value,
+        )
+    else:
+        instance_task = qhana_step_watcher.s(
+            topic_name=external_task.topic_name,
+            external_task_id=external_task.id,
+            execution_id=external_task.execution_id,
+            process_instance_id=external_task.process_instance_id,
+            step_data=qhana_var_value
+        )
+
+    instance_task.link_error(process_workflow_error.s(external_task_id=external_task.id))
+
+    instance_task.apply_async()
+
+
 @CELERY.task(
     name=f"{DeployWorkflow.instance.identifier}.external.camunda_task_watcher",
     ignore_result=True,
@@ -63,7 +130,13 @@ def camunda_task_watcher():
     camunda_client = CamundaClient(config)
     max_concurrent_external_tasks = config["max_concurrent_tasks"]
 
+    disable_legacy = config["workflow_conf"]["disable_legacy_support"]
+
+    qhana_task_topic = config["workflow_conf"]["qhana_task_topic"]
+
     TASK_LOGGER.info(f"Polling for external tasks as worker '{config['worker_id']}'.")
+    if not disable_legacy:
+        TASK_LOGGER.info("Polling with legacy workflow support enabled.")
 
     try:
         locked_task_count = camunda_client.get_locked_external_tasks_count()
@@ -74,7 +147,10 @@ def camunda_task_watcher():
         TASK_LOGGER.debug(
             f"Waiting on {locked_task_count} external tasks, fetching <= {max_tasks} new tasks."
         )
-        external_tasks = camunda_client.get_external_tasks(limit=max_tasks)
+        if disable_legacy:
+            external_tasks = camunda_client.get_external_tasks(limit=max_tasks, topic=qhana_task_topic)
+        else:
+            external_tasks = camunda_client.get_external_tasks(limit=max_tasks)
         TASK_LOGGER.info(f"Received {len(external_tasks)} tasks.")
     except RequestException as err:
         TASK_LOGGER.info(f"Error retrieving external tasks from camunda: {err}")
@@ -86,7 +162,7 @@ def camunda_task_watcher():
     # FIXME use non legacy settings here!!!
 
     TASK_LOGGER.debug(
-        f"Searching external task topics with prefix '{legacy_task_topic_prefix}.'"
+        f"Searching external task topics with prefixes '{legacy_task_topic_prefix}' and '{legacy_step_topic_prefix}'."
     )
 
     for external_task in external_tasks:
@@ -96,20 +172,28 @@ def camunda_task_watcher():
         if camunda_client.is_locked(external_task.id):
             continue
 
-        if topic_name.startswith(f"{legacy_step_topic_prefix}."):
-            # task is a qhana step
+        if topic_name == qhana_task_topic:
             execute_task(
                 external_task=external_task,
                 camunda_client=camunda_client,
-                watcher=qhana_step_watcher,
+                config=config["workflow_conf"],
             )
-        elif topic_name.startswith(f"{legacy_task_topic_prefix}."):
-            # task is a qhana plugin
-            execute_task(
-                external_task=external_task,
-                camunda_client=camunda_client,
-                watcher=qhana_instance_watcher,
-            )
+
+        if not disable_legacy:
+            if topic_name.startswith(f"{legacy_step_topic_prefix}."):
+                # task is a qhana step
+                execute_task_legacy(
+                    external_task=external_task,
+                    camunda_client=camunda_client,
+                    watcher=qhana_step_watcher,
+                )
+            elif topic_name.startswith(f"{legacy_task_topic_prefix}."):
+                # task is a qhana plugin
+                execute_task_legacy(
+                    external_task=external_task,
+                    camunda_client=camunda_client,
+                    watcher=qhana_instance_watcher,
+                )
 
 
 @CELERY.task(

--- a/tasks.py
+++ b/tasks.py
@@ -231,6 +231,9 @@ def start_camunda(c, port=None):
     if not dot_env_path.exists():
         dot_env_path.touch()
     set_key(dot_env_path, "CAMUNDA_CONTAINER_ID", result_container_id)
+    print("\nUseful Links:")
+    print(f"http://localhost:{port}/")
+    print(f"http://localhost:{port}/swaggerui/")
 
 
 @task(stop_broker, stop_camunda)


### PR DESCRIPTION
Refactor how the workflow to qhana plugin mapping works in the workflow plugin to better use camunda external task queues. Hopefully, this already implements everything required to utilize the changes made in the workflow editor transformation of QHAna plugin tasks to standard bpmn2 tasks.

- [ ] do not use topic names to convey relevant information (besides what kind of task should be executed)
- [ ] only use input variables to determine which plugin (version) should be called
- [ ] testing

