### PR TITLE
Add SQL plugin for data cleaning/processing

### DIFF
--- a/qhana_plugin_runner/static/microfrontend.js
+++ b/qhana_plugin_runner/static/microfrontend.js
@@ -19,6 +19,12 @@
 function registerMessageListener() {
     // main event listener, delegates events to dedicated listeners
     window.addEventListener("message", (event) => {
+        if (window._qhana_microfrontend_state.messageHandler != null) {
+            const eventHandled = window._qhana_microfrontend_state.messageHandler(event);
+            if (eventHandled) {
+                return;
+            }
+        }
         var data = event.data;
         if (typeof data === "string") {
             if (data === "ui-prevent-submit") {
@@ -602,7 +608,6 @@ function submitFormData(formData, formAction, formMethod) {
 
 
 // Main script entry point /////////////////////////////////////////////////////
-
 
 // only execute functions if loaded from a parent window (e.g. inside an iframe)
 if (window.top !== window.self) {

--- a/qhana_plugin_runner/templates/forms.html
+++ b/qhana_plugin_runner/templates/forms.html
@@ -23,9 +23,7 @@ form_label_class="qhana-form-label", form_input_class="qhana-form-input") -%}
   <div class="qhana-input-wrapper">
     {% if input_type == 'textarea' %}
     <textarea class="{{form_input_class}}" name="{{form_key}}" id="{{key}}" autocomplete="off" 
-      aria-describedby="{{key}}-description" {{ 'required' if field.required else '' }}>
-        {{values.get(form_key, '')}}
-    </textarea>
+      aria-describedby="{{key}}-description" {{ 'required' if field.required else '' }}>{{values.get(form_key, '')}}</textarea>
     {% elif input_type == "select" %}
     <select class="{{form_input_class}}" name="{{form_key}}" id="{{key}}" autocomplete="off">
       {% for name, value in field.metadata.get("options", extras.get(key, {}).get("options", {}) if extras else {}).items() %}

--- a/qhana_plugin_runner/templates/forms.html
+++ b/qhana_plugin_runner/templates/forms.html
@@ -22,8 +22,10 @@ form_label_class="qhana-form-label", form_input_class="qhana-form-input") -%}
 
   <div class="qhana-input-wrapper">
     {% if input_type == 'textarea' %}
-    <textarea class="{{form_input_class}}" name="{{form_key}}" id="{{key}}" autocomplete="off" {{ 'required' if
-      field.required else '' }}>{{values.get(form_key, '')}}</textarea>
+    <textarea class="{{form_input_class}}" name="{{form_key}}" id="{{key}}" autocomplete="off" 
+      aria-describedby="{{key}}-description" {{ 'required' if field.required else '' }}>
+        {{values.get(form_key, '')}}
+    </textarea>
     {% elif input_type == "select" %}
     <select class="{{form_input_class}}" name="{{form_key}}" id="{{key}}" autocomplete="off">
       {% for name, value in field.metadata.get("options", extras.get(key, {}).get("options", {}) if extras else {}).items() %}
@@ -32,7 +34,7 @@ form_label_class="qhana-form-label", form_input_class="qhana-form-input") -%}
     </select>
     {% elif input_type == 'text_with_datalist' %}
     <input class="{{form_input_class}}" type="text" name="{{form_key}}" id="{{key}}" autocomplete="off"
-      aria-describedby="{{key}}-description" {{required if field.required else '' }} {{ get_validation_attrs(field) }}
+      aria-describedby="{{key}}-description" {{ 'required' if field.required else '' }} {{ get_validation_attrs(field) }}
       list="{{key}}-datalist" {{ field_value(input_type, values.get(form_key)) }}>
     {% set datalist=get_datalist_from_schema(schema, key, extras) %}
     {% if datalist %}

--- a/qhana_plugin_runner/util/debug_routes/root.py
+++ b/qhana_plugin_runner/util/debug_routes/root.py
@@ -17,10 +17,17 @@
 """Module for the root endpoint of the debug routes.
 Contains the blueprint to avoid circular dependencies."""
 
-from flask import Blueprint, render_template
+from json import dumps
+
+from flask import Blueprint, current_app, render_template, url_for
+from werkzeug.routing import converters
 
 DEBUG_BLP = Blueprint(
-    "debug-routes", __name__, template_folder="templates", url_prefix="/debug"
+    "debug-routes",
+    __name__,
+    template_folder="templates",
+    static_folder="static",
+    url_prefix="/debug",
 )
 
 
@@ -28,3 +35,98 @@ DEBUG_BLP = Blueprint(
 @DEBUG_BLP.route("/index")
 def index():
     return render_template("debug/index.html", title="QHAna Plugin Runner – Debug")
+
+
+MESSAGE_TEMPLATES = {
+    "prevent submit": "ui-prevent-submit",
+    "allow submit": "ui-allow-submit",
+    "get submit status": "ui-submit-status",
+    "load css": {
+        "type": "load-css",
+        "urls": [],
+    },
+    "data url response": {
+        "type": "data-url-response",
+        "inputKey": "",
+        "href": "",
+        "dataType": "entity/list",
+        "contentType": "text/csv",
+        "filename": "test.csv",
+        "version": "v1",
+    },
+    "plugin url response": {
+        "type": "plugin-url-response",
+        "inputKey": "",
+        "pluginUrl": "",
+        "pluginName": "Hello World",
+        "pluginVersion": "v1.0.0",
+    },
+    "implementations response": {
+        "type": "implementations-response",
+        "implementations": [
+            {"name": "test.qasm", "download": "http://", "version": 1, "type": "qasm??"}
+        ],
+    },
+    "autofill": {
+        "type": "autofill-response",
+        "value": "",
+        "encoding": "application/x-www-form-urlencoded",
+    },
+    "plugin context": {
+        "type": "plugin-context",
+        "experimentId": "",
+        "location": "navigation|workspace|experiment-navigation|timeline-step|data-preview",
+    },
+}
+
+
+@DEBUG_BLP.route("/frontend-debugger")
+def frontend_debugger():
+    """Debugger for Micro Frontends."""
+
+    micro_frontend_urls = []  # TODO
+
+    for rule in current_app.url_map.iter_rules():
+        if (
+            not rule.rule.startswith("/plugins/")
+            or rule.rule.count("/") < 3
+            or not rule.rule.split("/", maxsplit=3)[3]
+            or "GET" not in rule.methods
+        ):
+            continue
+
+        rule_converters = rule._converters
+
+        def replaced(argument: str):
+            argument_converter = rule_converters[argument]
+            if isinstance(argument_converter, converters.NumberConverter):
+                return 1
+            replacement = f"{{{{{argument}}}}}"
+
+            # check converter
+            argument_converter.to_url(replacement)
+            return replacement
+
+        try:
+            arguments = {a: replaced(a) for a in rule.arguments}
+        except Exception:
+            continue  # cannot build this URL, skip
+        url = url_for(rule.endpoint, **arguments, _external=True)
+        micro_frontend_urls.append(url)
+
+    if not MESSAGE_TEMPLATES["load css"]["urls"]:
+        MESSAGE_TEMPLATES["load css"]["urls"].append(
+            url_for(
+                "debug-routes.static",
+                filename="microfrontend-debug.css",
+                _external=True,
+            )
+        )
+
+    message_templates = {k: dumps(v, indent=4) for k, v in MESSAGE_TEMPLATES.items()}
+    return render_template(
+        "debug/microfrontend-debugger.html",
+        title="QHAna Plugin Runner – Micro Frontend Debugger",
+        micro_frontend_urls=micro_frontend_urls,
+        message_templates=message_templates,
+    )

--- a/qhana_plugin_runner/util/debug_routes/static/microfrontend-debug.css
+++ b/qhana_plugin_runner/util/debug_routes/static/microfrontend-debug.css
@@ -1,0 +1,406 @@
+:root {
+    --background: white;
+    --background-card: #ddd;
+    --border-color: #aaa;
+    --scroll-background: #ddd;
+    --scroll-color: #888;
+    --text: black;
+    --text-inv: white;
+    --text-washed: #222;
+    --text-disabled: #444;
+    --primary: #0b0089;
+    --primary-darker: #06004b;
+    --primary-lighter: #1000c6;
+    --primary-text: #0b0089;
+    --primary-text-visited: #06004b;
+    --accent: #b25300;
+    --accent-darker: #833d00;
+    --accent-lighter: #dc6803;
+    --accent-text: #b25300;
+    --warn: #de0000;
+    --warn-darker: #8a0000;
+    --warn-lighter: #ff2d2d;
+    --warn-text: #de0000;
+    --text-primary: white;
+    --text-primary-lighter: var(--text, black);
+    --text-primary-darker: var(--text-primary);
+    --text-accent: white;
+    --text-warn: white;
+    --line: 150,150,150;
+}
+
+/* expose typography as css classes */
+.t-page-headline {
+    margin-block: 0.8ex
+}
+
+.t-headline {
+}
+
+.t-title {
+}
+
+.t-subheading {
+}
+
+.t-subsubheading {
+}
+
+.t-paragraph {
+}
+
+.text {
+    color: var(--text, black);
+}
+
+.text-primary {
+    color: var(--text-primary);
+}
+
+.text-light-primary {
+    color: var(--text-light-primary);
+}
+
+html, body {
+    height: 100%;
+    height: stretch;
+}
+
+body {
+    margin: 0;
+    font-family: Inter, "Helvetica Neue", sans-serif;
+    background-color: var(--background, white);
+    color: var(--text, black);
+}
+
+a {
+    color: var(--primary-text);
+}
+
+::any-link {
+    color: var(--primary-text);
+}
+
+a:hover, a:visited {
+    color: var(--primary-text-visited);
+}
+
+::any-link:hover, ::any-link:visited {
+    color: var(--primary-text-visited)
+}
+
+::selection {
+    background-color: var(--primary-lighter);
+    color: var(--text-primary-lighter, black);
+}
+
+/* overwrite flex or grid display for hidden nodes */
+*[hidden] {
+    display: none !important;
+}
+
+/*//////////////////////////////////////////////////////////////////////////////
+// top level classes applying to all components ////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////*/
+
+.scrollable {
+    scrollbar-color: var(--scroll-color) var(--scroll-background);
+}
+
+.big-content {
+    max-width: 60rem;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
+}
+
+.title-link {
+    color: var(--primary-text);
+}
+
+.title-link:visited {
+    color: var(--primary-text-visited);
+}
+
+.scroll-spacer {
+    height: 20vh;
+}
+
+.bold {
+    font-weight: 500;
+}
+
+.italic {
+    font-style: italic;
+}
+
+.break-words {
+    overflow-wrap: break-word;
+}
+
+.break-all {
+    word-break: break-all;
+}
+
+.file-input {
+    color: var(--text);
+    background-color: var(--background);
+    border: 2px solid var(--border-color, currentColor);
+    border-radius: 5px;
+    max-width: initial;
+    box-sizing: border-box;
+    padding-inline: 0.5rem;
+    padding-block: 1.3ex;
+}
+
+.file-input:focus:not(:focus-visible) {
+    outline: none;
+}
+
+.file-input:focus-visible {
+    outline: 4px solid var(--accent-darker, black);
+}
+
+.file-input::file-selector-button {
+    right: 0px;
+    margin: 0.4rem;
+    padding-inline: 1em;
+    background-color: var(--primary, purple);
+    color: var(--text-primary, white);
+    cursor: pointer;
+    outline: none;
+    border: none;
+    border-radius: 4px;
+    font-size: 14px;
+    line-height: 36px;
+    font-weight: 600;
+}
+
+.file-input::file-selector-button:hover {
+    background-color: var(--primary, purple);
+    color: var(--text-primary, white);
+}
+
+.file-input::file-selector-button:active {
+    background-color: var(--primary-lighter, purple);
+}
+
+.file-input::file-selector-button:focus-visible {
+    outline: 4px solid var(--accent-darker, black);
+}
+
+/* extra helpers */
+.strip-button-hover:hover .mat-mdc-button-focus-overlay {
+    background: transparent;
+}
+
+summary.no-decoration {
+    list-style: none;
+}
+
+summary.no-decoration::marker, summary.no-decoration::-webkit-details-marker {
+    content: none;
+    display: none;
+}
+
+/* qhana form inputs (from micro frontends) */
+
+form.qhana-form {
+    max-width: initial;
+}
+
+.qhana-form-label {
+    font-weight: 500;
+    padding-inline-start: 0.5rem;
+    color: var(--border-color, currentColor);
+}
+
+.qhana-form-input, input.qhana-form-input, select.qhana-form-input, textarea.qhana-form-input {
+    color: var(--text);
+    background-color: var(--background);
+    border: 2px solid var(--border-color, currentColor);
+    border-radius: 5px;
+    max-width: initial;
+    box-sizing: border-box;
+    padding-inline: 0.5rem;
+    padding-block: 1.3ex;
+}
+
+.qhana-form-input:focus {
+    outline: none;
+}
+
+.qhana-form-field {
+    margin-block-end: 0.8rem;
+    --border-color: var(--text-washed, #333);
+}
+
+.qhana-form-field:hover:not(:focus-within) {
+    --border-color: var(--text, black);
+}
+
+.qhana-form-field:focus-within {
+    --border-color: var(--primary-text, black);
+}
+
+.qhana-form-input:focus-visible {
+    outline: 4px solid var(--accent-darker, black);
+}
+
+.qhana-form-submit {
+    margin: 0.4rem;
+    padding-inline: 1em;
+    background-color: var(--primary, purple);
+    color: var(--text-primary, white);
+    cursor: pointer;
+    outline: none;
+    border: none;
+    border-radius: 4px;
+    font-size: 14px;
+    line-height: 36px;
+    font-weight: 500;
+}
+
+.qhana-form-submit:active {
+    background-color: var(--primary-lighter, purple);
+}
+
+.qhana-form-submit:focus-visible {
+    outline: 4px solid var(--accent-darker, black);
+}
+
+.qhana-choose-file-button, .qhana-choose-plugin-button {
+    padding-inline: 0.5rem;
+    padding-block: 1.3ex;
+    color: var(--primary-text, purple);
+    background-color: var(--background, white);
+    cursor: pointer;
+    outline: none;
+    border: 2px solid var(--primary-text, purple);
+    border-radius: 4px;
+    font-weight: 500;
+}
+
+.qhana-choose-file-button:hover:not([disabled]), .qhana-choose-plugin-button:hover:not([disabled]) {
+    background-color: var(--primary, purple);
+    color: var(--text-primary, white);
+}
+
+.qhana-choose-file-button:active:not([disabled]), .qhana-choose-plugin-button:active:not([disabled]) {
+    background-color: var(--primary-lighter, purple);
+    color: var(--text-dark-primary, black);
+}
+
+.qhana-choose-file-button:focus-visible, .qhana-choose-plugin-button:focus-visible {
+    outline: 4px solid var(--accent-darker, black);
+}
+
+.qhana-choose-file-button[disabled], .qhana-choose-plugin-button[disabled] {
+    cursor: revert;
+    color: var(--text-disabled, black);
+    border-color: var(--text-disabled, black);
+}
+
+.qhana-show-preview-button {
+    display: inline-block;
+    padding-inline: 0.5rem;
+    padding-block: 0.3ex;
+    color: var(--primary-text, purple);
+    background-color: transparent;
+    cursor: pointer;
+    outline: none;
+    border: none;
+    border-radius: 4px;
+    font-weight: 500;
+}
+
+.qhana-show-preview-button:hover {
+    background-color: var(--primary, purple);
+    color: var(--text-primary, white);
+}
+
+.qhana-show-preview-button:active {
+    background-color: var(--primary-lighter, purple);
+    color: var(--text-dark-primary, black);
+}
+
+.qhana-show-preview-button:focus-visible {
+    outline: 4px solid var(--accent-darker, black);
+}
+
+.qhana-input-description {
+}
+
+.qhana-input-description p {
+    margin-block: 0.1em;
+}
+
+.qhana-error-message {
+    color: var(--warn-text, red);
+}
+
+.qhana-valid-icon {
+    color: rgb(0, 247, 0);
+}
+
+.plugin-micro-frontend {
+}
+
+.plugin-micro-frontend h1 {
+}
+
+.plugin-micro-frontend h2 {
+}
+
+.plugin-micro-frontend h3 {
+}
+
+.plugin-micro-frontend h4 {
+}
+
+.qhana-table {
+    flex-direction: row;
+    flex-wrap: wrap;
+    overflow: auto;
+    border: 2px solid var(--border-color, currentColor);
+    border-radius: 5px;
+}
+
+.qhana-table table {
+    border-collapse: collapse;
+}
+
+.qhana-table td, .qhana-table th {
+    border: 2px solid var(--border-color, currentColor);
+    text-align: left;
+    padding: 0.5em;
+}
+
+.qhana-table th {
+    padding-top: 1em;
+    padding-bottom: 1em;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background-color: var(--primary, purple);
+    text-decoration-color: white;
+}
+
+.qhana-table tr:hover {
+    background-color: var(--primary, currentColor);
+}
+
+.qhana-table tr:first-child th {
+    border-top: 0;
+}
+
+.qhana-table tr:last-child td {
+    border-bottom: 0;
+}
+
+.qhana-table tr td:first-child, .qhana-table tr th:first-child {
+    border-left: 0;
+}
+
+.qhana-table tr td:last-child, .qhana-table tr th:last-child {
+    border-right: 0;
+}

--- a/qhana_plugin_runner/util/debug_routes/templates/debug/index.html
+++ b/qhana_plugin_runner/util/debug_routes/templates/debug/index.html
@@ -15,6 +15,7 @@
 
     <ul>
         <li><a href="{{url_for('debug-routes.routes')}}">Routes</a></li>
+        <li><a href="{{url_for('debug-routes.frontend_debugger')}}">Micro Frontend Debugger</a></li>
     </ul>
 
 </body>

--- a/qhana_plugin_runner/util/debug_routes/templates/debug/microfrontend-debugger.html
+++ b/qhana_plugin_runner/util/debug_routes/templates/debug/microfrontend-debugger.html
@@ -1,0 +1,179 @@
+{% import 'forms.html' as forms %}
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+    <base href="/">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <style>
+        .content {
+            display: flex;
+            flex-direction: column;
+            min-width: 50ch;
+            max-width: max-content;
+            margin-inline: auto;
+            gap: 1em;
+        }
+
+        .content form {
+            min-width: 50ch;
+            width: 80ch;
+        }
+        .content iframe {
+            width: 100%;
+            resize: both;
+        }
+
+        .single-line-form {
+            display: flex;
+            gap: 0.5em;
+            justify-content: space-between;
+        }
+
+        .single-line-form input {
+            flex-grow: 1;
+        }
+        .multi-line-form {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5em;
+            align-items: stretch;
+        }
+
+        .button-list {
+            list-style: none;
+            display: flex;
+            flex-wrap: wrap;
+            max-width: 80ch;
+            gap: 0.5em;
+            margin-block: 0.5em;
+            padding-inline: 0em;
+        }
+
+        textarea#message_input {
+            min-height: 6lh;
+            field-sizing: content;
+        }
+
+        .container {
+            border: 1px solid black;
+            min-height: 1em;
+        }
+
+        .message-log {
+            font: monospace;
+            max-height: 50vh;
+            max-width: 80ch;
+            scrollbar-gutter: both-edges;
+            overflow: auto;
+        }
+        .message-log > pre {
+            margin-block: 0px;
+            padding-inline: 0.5em;
+            width: stretch;
+        }
+        .message-log > :nth-child(even) {
+            background-color: lightgray;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="content">
+        <form id="frontend_url" class="single-line-form">
+            <label for="input_url">URL:</label>
+            <input type="url" name="url" id="input_url" list="micro_frontends">
+            <datalist id="micro_frontends">
+                {% for url in micro_frontend_urls %}
+                <option value="{{url}}">{{url}}</option>
+                {% endfor %}
+            </datalist>
+            <button type="submit">load frontend</button>
+        </form>
+
+        <details open>
+            <summary>
+                Messages
+            </summary>
+            <ul class="button-list" id="message_templates">
+                {% for key, message in message_templates.items() %}
+                <li><button data-value="{{message}}">{{key}}</button></li>
+                {% endfor %}
+            </ul>
+            <form id="message_form" class="multi-line-form">
+                <label for="message_input">Message to send:</label>
+                <textarea name="message" id="message_input" autocomplete="off" spellcheck="false"></textarea>
+                <button type="submit">send message</button>
+            </form>
+
+            <p>Message Log:</p>
+            <div class="container">
+                <div class="message-log" id="message_log">
+                </div>
+            </div>
+        </details>
+
+        <iframe id="plugin_iframe" seamless class="frontend-frame" frameborder="1" scroll="no" height="600"
+            sandbox="allow-forms allow-downloads allow-scripts allow-same-origin" allow="fullscreen">
+        </iframe>
+    </div>
+
+    <script>
+        document.querySelector("form#frontend_url").addEventListener("submit", (event) => {
+            event.preventDefault();
+            const url = document.querySelector("input#input_url").value;
+            const iframe = document.querySelector("iframe#plugin_iframe");
+            if (url) {
+                iframe.setAttribute("src", url);
+            } else {
+                iframe.removeAttribute("src");
+            }
+        });
+
+
+        document.querySelector("textarea#message_input").addEventListener("change", (event) => event.target.setCustomValidity(""));
+        document.querySelector("#message_templates").addEventListener("click", (event) => {
+            const data = event.target.dataset.value;
+            if (data) {
+                document.querySelector("textarea#message_input").value = data;
+            }
+        });
+        document.querySelector("form#message_form").addEventListener("submit", (event) => {
+            event.preventDefault();
+
+            /** @type {HTMLTextAreaElement} */
+            const formInput = document.querySelector("textarea#message_input");
+            let message;
+            try {
+                message = JSON.parse(formInput.value.trim());
+                formInput.setCustomValidity("");
+            } catch (err) {
+                console.log(err)
+                formInput.setCustomValidity(err.toString());
+                formInput.reportValidity();
+                return;
+            }
+
+            const log = document.querySelector("#message_log");
+            const logEntry = document.createElement("pre");
+            logEntry.textContent = ">>> " + JSON.stringify(message, undefined, 4);
+            const iframe = document.querySelector("iframe#plugin_iframe");
+            iframe.contentWindow.postMessage(message, this.pluginOrigin ?? "*");
+            log.appendChild(logEntry);
+        });
+
+        window.addEventListener("message", (event) => {
+            const message = JSON.stringify(event.data, undefined, 4);
+            const log = document.querySelector("#message_log");
+            const logEntry = document.createElement("pre");
+            logEntry.textContent = message;
+            log.appendChild(logEntry);
+        });
+    
+    </script>
+
+</body>
+
+</html>

--- a/stable_plugins/classical_ml/data_preparation/README.md
+++ b/stable_plugins/classical_ml/data_preparation/README.md
@@ -1,6 +1,7 @@
 This folder contains plugins that do classical data preparation like one-hot encoding and filtering.
 
 The following dependencies are used by these plugins:
+- duckdb~=1.4.2
 - muid~=0.5.3
 - pandas~=1.5.0
 - pretty-html-table~=0.9.16

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/__init__.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/__init__.py
@@ -1,0 +1,6 @@
+from .plugin import SQLEditor
+
+_plugin_name = SQLEditor.name
+__version__ = SQLEditor.version
+
+from . import routes

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/__init__.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/__init__.py
@@ -3,4 +3,4 @@ from .plugin import SQLEditor
 _plugin_name = SQLEditor.name
 __version__ = SQLEditor.version
 
-from . import routes
+from . import routes  # noqa: F401,E402

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/plugin.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/plugin.py
@@ -5,7 +5,7 @@ from flask import Blueprint, Flask
 from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
 
-_name = "duckdb"
+_name = "sql-editor"
 _version = "v0.1.0"
 
 

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/plugin.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/plugin.py
@@ -1,0 +1,43 @@
+from typing import ClassVar, Optional
+
+from flask import Blueprint, Flask
+
+from qhana_plugin_runner.api.util import SecurityBlueprint
+from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
+
+_name = "duckdb"
+_version = "v0.1.0"
+
+
+SQL_BLP = SecurityBlueprint(
+    plugin_identifier(_name, _version),
+    __name__,
+    description="SQL Plugin using DuckDB.",
+    template_folder="templates",
+)
+
+
+class SQLEditor(QHAnaPluginBase):
+    name = _name
+    version = _version
+    description = "A plugin to use SQL for data loading or data cleaning."
+    tags = ["sql", "duckdb", "preprocessing", "data-cleaning"]
+
+    instance: ClassVar["SQLEditor"]
+
+    _blueprint: Optional[Blueprint] = None
+
+    def __init__(self, app: Optional[Flask]) -> None:
+        super().__init__(app)
+
+    def init_app(self, app: Flask):
+        super().init_app(app)
+
+    def get_requirements(self) -> str:
+        return "duckdb~=1.4.2"
+
+    def get_api_blueprint(self):
+        if not self._blueprint:
+            self._blueprint = SQL_BLP
+            return SQL_BLP
+        return self._blueprint

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
@@ -46,7 +46,10 @@ class PluginRootView(MethodView):
                 ui_href=url_for(f"{SQL_BLP.name}.{SQLFrontend.__name__}", _external=True),
                 data_input=[
                     InputDataMetadata(
-                        "*", content_type=["application/json", "text/csv"], required=False
+                        "*",
+                        content_type=["application/json", "text/csv"],
+                        parameter="sql",
+                        required=False,
                     )
                 ],
                 data_output=[],
@@ -55,7 +58,7 @@ class PluginRootView(MethodView):
         )
 
 
-@SQL_BLP.route("/wf-editor-ui/")
+@SQL_BLP.route("/ui/")
 class SQLFrontend(MethodView):
     """Micro frontend for the sql editor plugin."""
 

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
@@ -1,0 +1,112 @@
+from http import HTTPStatus
+from typing import Literal, Mapping
+
+from flask import current_app, render_template
+from flask.globals import request
+from flask.helpers import url_for
+from flask.views import MethodView
+from flask.wrappers import Response
+from flask_smorest import abort
+from kombu.exceptions import OperationalError
+from marshmallow import EXCLUDE
+
+from qhana_plugin_runner.api.plugin_schemas import (
+    EntryPoint,
+    InputDataMetadata,
+    PluginMetadata,
+    PluginMetadataSchema,
+    PluginType,
+)
+
+from .plugin import SQL_BLP, SQLEditor
+from .schemas import SQLInputSchema
+from .tasks import process_sql
+
+
+@SQL_BLP.route("/")
+class PluginRootView(MethodView):
+    """Plugin for using SQL for data processing."""
+
+    @SQL_BLP.response(HTTPStatus.OK, PluginMetadataSchema())
+    @SQL_BLP.require_jwt("jwt", optional=True)
+    def get(self):
+        """Endpoint returning the plugin metadata"""
+
+        return PluginMetadata(
+            title="SQL Editor",
+            description="Use SQL to process or filter existing data.",
+            name=SQLEditor.instance.name,
+            version=SQLEditor.instance.version,
+            type=PluginType.interaction,
+            entry_point=EntryPoint(
+                href=url_for(
+                    f"{SQL_BLP.name}.{ProcessSQL.__name__}",
+                    _external=True,
+                ),
+                ui_href=url_for(f"{SQL_BLP.name}.{SQLFrontend.__name__}", _external=True),
+                data_input=[
+                    InputDataMetadata(
+                        "*", content_type=["application/json", "text/csv"], required=False
+                    )
+                ],
+                data_output=[],
+            ),
+            tags=SQLEditor.instance.tags,
+        )
+
+
+@SQL_BLP.route("/wf-editor-ui/")
+class SQLFrontend(MethodView):
+    """Micro frontend for the sql editor plugin."""
+
+    @SQL_BLP.html_response(
+        HTTPStatus.OK,
+        description="Micro frontend for the sql editor plugin.",
+    )
+    @SQL_BLP.require_jwt("jwt", optional=True)
+    def get(self):
+        """Return the micro frontend."""
+
+        return self.render({}, {}, True)
+
+    @SQL_BLP.html_response(
+        HTTPStatus.OK,
+        description="Micro frontend for the sql editor plugin.",
+    )
+    @SQL_BLP.arguments(
+        SQLInputSchema(partial=True, unknown=EXCLUDE, validate_errors_as_result=True),
+        location="form",
+        required=False,
+    )
+    @SQL_BLP.require_jwt("jwt", optional=True)
+    def post(self, errors):
+        """Return the micro frontend with pre-rendered inputs."""
+        return self.render(request.form, errors, not errors)
+
+    def render(self, data: Mapping, errors: dict, valid: bool):
+        plugin = SQLEditor.instance
+        if plugin is None:
+            abort(HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        schema = SQLInputSchema()
+        return Response(
+            render_template(
+                "sql-editor.html",
+                name=plugin.name,
+                version=plugin.version,
+                schema=schema,
+                valid=valid,
+                values=data,
+                errors=errors,
+                process=url_for(f"{SQL_BLP.name}.{ProcessSQL.__name__}"),
+            )
+        )
+
+
+@SQL_BLP.route("/process/")
+class ProcessSQL(MethodView):
+    """TODO."""
+
+    @SQL_BLP.require_jwt("jwt", optional=True)
+    def get(self):
+        return ""

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
@@ -3,11 +3,11 @@ from json import dumps
 from typing import Mapping
 
 from celery.canvas import chain
-from flask import jsonify, redirect, render_template
+import celery
+from flask import Response, current_app, jsonify, redirect, render_template
 from flask.globals import request
 from flask.helpers import url_for
 from flask.views import MethodView
-from flask.wrappers import Response
 from flask_smorest import abort
 from marshmallow import EXCLUDE
 
@@ -24,7 +24,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 
 from .plugin import SQL_BLP, SQLEditor
 from .schemas import SQLInputSchema
-from .tasks import process_sql
+from .tasks import preview_sql, process_sql
 from .util import PREVIEW_LIMIT, execute_sql, serialize_rows, validate_sql
 
 
@@ -59,7 +59,7 @@ class PluginRootView(MethodView):
                 ],
                 data_output=[
                     DataMetadata(
-                        data_type="entity/list",
+                        data_type="*",
                         content_type=["text/csv", "application/json"],
                         required=True,
                     )
@@ -104,8 +104,8 @@ class SQLFrontend(MethodView):
 
         render_errors = dict(errors) if errors else {}
         sql_value = (data.get("sql") or "").strip()
-        if sql_value:
-            sql_error, _ = validate_sql(sql_value)
+        if sql_value and "sql" not in render_errors:
+            sql_error = validate_sql(sql_value)
             if sql_error:
                 render_errors.setdefault("sql", []).append(sql_error)
                 valid = False
@@ -134,11 +134,7 @@ class CheckSQL(MethodView):
     @SQL_BLP.arguments(SQLInputSchema(unknown=EXCLUDE), location="form")
     @SQL_BLP.require_jwt("jwt", optional=True)
     def post(self, arguments):
-        sql = arguments.get("sql", "")
-        error, _ = validate_sql(sql)
-        if error:
-            return jsonify({"ok": False, "error": error}), HTTPStatus.BAD_REQUEST
-        return jsonify({"ok": True})
+        return Response(status=HTTPStatus.NO_CONTENT)
 
 
 @SQL_BLP.route("/preview/")
@@ -149,8 +145,31 @@ class PreviewSQL(MethodView):
     @SQL_BLP.require_jwt("jwt", optional=True)
     def post(self, arguments):
         sql = arguments.get("sql", "")
+        use_celery = current_app.config.get("SQL_EDITOR_PREVIEW_USE_CELERY", False)
+        preview_timeout = current_app.config.get("SQL_EDITOR_PREVIEW_TIMEOUT_SEC", 10)
         try:
-            columns, rows = execute_sql(sql, limit=PREVIEW_LIMIT)
+            if use_celery:
+                task_result = preview_sql.s(sql, PREVIEW_LIMIT).apply_async()
+                try:
+                    payload = task_result.get(timeout=preview_timeout)
+                except celery.exceptions.TimeoutError:
+                    task_result.revoke(terminate=True)
+                    return (
+                        jsonify(
+                            {
+                                "ok": False,
+                                "error": (
+                                    f"Preview timed out after {preview_timeout} seconds."
+                                ),
+                            }
+                        ),
+                        HTTPStatus.REQUEST_TIMEOUT,
+                    )
+                columns = payload.get("columns", [])
+                serialized_rows = payload.get("rows", [])
+            else:
+                columns, rows = execute_sql(sql, limit=PREVIEW_LIMIT)
+                serialized_rows = list(serialize_rows(rows))
         except ValueError as err:
             return (
                 jsonify({"ok": False, "error": str(err)}),
@@ -162,7 +181,6 @@ class PreviewSQL(MethodView):
                 HTTPStatus.BAD_REQUEST,
             )
 
-        serialized_rows = serialize_rows(rows)
         return jsonify(
             {
                 "ok": True,
@@ -184,9 +202,6 @@ class ProcessSQL(MethodView):
     @SQL_BLP.require_jwt("jwt", optional=True)
     def post(self, arguments):
         sql = arguments.get("sql", "")
-        error, _ = validate_sql(sql)
-        if error:
-            abort(HTTPStatus.BAD_REQUEST, message=error)
 
         db_task = ProcessingTask(task_name=process_sql.name, parameters=dumps(arguments))
         db_task.save(commit=True)

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
@@ -1,26 +1,31 @@
 from http import HTTPStatus
-from typing import Literal, Mapping
+from json import dumps
+from typing import Mapping
 
-from flask import current_app, render_template
+from celery.canvas import chain
+from flask import jsonify, redirect, render_template
 from flask.globals import request
 from flask.helpers import url_for
 from flask.views import MethodView
 from flask.wrappers import Response
 from flask_smorest import abort
-from kombu.exceptions import OperationalError
 from marshmallow import EXCLUDE
 
 from qhana_plugin_runner.api.plugin_schemas import (
+    DataMetadata,
     EntryPoint,
     InputDataMetadata,
     PluginMetadata,
     PluginMetadataSchema,
     PluginType,
 )
+from qhana_plugin_runner.db.models.tasks import ProcessingTask
+from qhana_plugin_runner.tasks import save_task_error, save_task_result
 
 from .plugin import SQL_BLP, SQLEditor
 from .schemas import SQLInputSchema
 from .tasks import process_sql
+from .util import PREVIEW_LIMIT, execute_sql, serialize_rows, validate_sql
 
 
 @SQL_BLP.route("/")
@@ -37,7 +42,7 @@ class PluginRootView(MethodView):
             description="Use SQL to process or filter existing data.",
             name=SQLEditor.instance.name,
             version=SQLEditor.instance.version,
-            type=PluginType.interaction,
+            type=PluginType.processing,
             entry_point=EntryPoint(
                 href=url_for(
                     f"{SQL_BLP.name}.{ProcessSQL.__name__}",
@@ -52,7 +57,13 @@ class PluginRootView(MethodView):
                         required=False,
                     )
                 ],
-                data_output=[],
+                data_output=[
+                    DataMetadata(
+                        data_type="entity/list",
+                        content_type=["text/csv", "application/json"],
+                        required=True,
+                    )
+                ],
             ),
             tags=SQLEditor.instance.tags,
         )
@@ -91,6 +102,14 @@ class SQLFrontend(MethodView):
         if plugin is None:
             abort(HTTPStatus.INTERNAL_SERVER_ERROR)
 
+        render_errors = dict(errors) if errors else {}
+        sql_value = (data.get("sql") or "").strip()
+        if sql_value:
+            sql_error, _ = validate_sql(sql_value)
+            if sql_error:
+                render_errors.setdefault("sql", []).append(sql_error)
+                valid = False
+
         schema = SQLInputSchema()
         return Response(
             render_template(
@@ -100,16 +119,86 @@ class SQLFrontend(MethodView):
                 schema=schema,
                 valid=valid,
                 values=data,
-                errors=errors,
+                errors=render_errors,
                 process=url_for(f"{SQL_BLP.name}.{ProcessSQL.__name__}"),
+                check=url_for(f"{SQL_BLP.name}.{CheckSQL.__name__}"),
+                preview=url_for(f"{SQL_BLP.name}.{PreviewSQL.__name__}"),
             )
+        )
+
+
+@SQL_BLP.route("/check/")
+class CheckSQL(MethodView):
+    """Endpoint to validate SQL syntax and basic safety."""
+
+    @SQL_BLP.arguments(SQLInputSchema(unknown=EXCLUDE), location="form")
+    @SQL_BLP.require_jwt("jwt", optional=True)
+    def post(self, arguments):
+        sql = arguments.get("sql", "")
+        error, _ = validate_sql(sql)
+        if error:
+            return jsonify({"ok": False, "error": error}), HTTPStatus.BAD_REQUEST
+        return jsonify({"ok": True})
+
+
+@SQL_BLP.route("/preview/")
+class PreviewSQL(MethodView):
+    """Endpoint to preview SQL output."""
+
+    @SQL_BLP.arguments(SQLInputSchema(unknown=EXCLUDE), location="form")
+    @SQL_BLP.require_jwt("jwt", optional=True)
+    def post(self, arguments):
+        sql = arguments.get("sql", "")
+        try:
+            columns, rows = execute_sql(sql, limit=PREVIEW_LIMIT)
+        except ValueError as err:
+            return (
+                jsonify({"ok": False, "error": str(err)}),
+                HTTPStatus.BAD_REQUEST,
+            )
+        except Exception as err:
+            return (
+                jsonify({"ok": False, "error": str(err)}),
+                HTTPStatus.BAD_REQUEST,
+            )
+
+        serialized_rows = serialize_rows(rows)
+        return jsonify(
+            {
+                "ok": True,
+                "columns": columns,
+                "rows": serialized_rows,
+                "limit": PREVIEW_LIMIT,
+                "row_count": len(serialized_rows),
+                "truncated": len(serialized_rows) == PREVIEW_LIMIT,
+            }
         )
 
 
 @SQL_BLP.route("/process/")
 class ProcessSQL(MethodView):
-    """TODO."""
+    """Start a long running processing task."""
 
+    @SQL_BLP.arguments(SQLInputSchema(unknown=EXCLUDE), location="form")
+    @SQL_BLP.response(HTTPStatus.SEE_OTHER)
     @SQL_BLP.require_jwt("jwt", optional=True)
-    def get(self):
-        return ""
+    def post(self, arguments):
+        sql = arguments.get("sql", "")
+        error, _ = validate_sql(sql)
+        if error:
+            abort(HTTPStatus.BAD_REQUEST, message=error)
+
+        db_task = ProcessingTask(task_name=process_sql.name, parameters=dumps(arguments))
+        db_task.save(commit=True)
+
+        task: chain = process_sql.s(db_id=db_task.id) | save_task_result.s(
+            db_id=db_task.id
+        )
+        task.link_error(save_task_error.s(db_id=db_task.id))
+        task.apply_async()
+
+        db_task.save(commit=True)
+
+        return redirect(
+            url_for("tasks-api.TaskView", task_id=str(db_task.id)), HTTPStatus.SEE_OTHER
+        )

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
@@ -10,6 +10,7 @@ from flask.helpers import url_for
 from flask.views import MethodView
 from flask_smorest import abort
 from marshmallow import EXCLUDE
+from werkzeug.exceptions import HTTPException
 
 from qhana_plugin_runner.api.plugin_schemas import (
     DataMetadata,
@@ -148,22 +149,17 @@ class PreviewSQL(MethodView):
                     payload = task_result.get(timeout=preview_timeout)
                 except celery.exceptions.TimeoutError:
                     task_result.revoke(terminate=True)
-                    return (
-                        jsonify(
-                            {
-                                "ok": False,
-                                "error": (
-                                    f"Preview timed out after {preview_timeout} seconds."
-                                ),
-                            }
-                        ),
+                    abort(
                         HTTPStatus.REQUEST_TIMEOUT,
+                        message=f"Preview timed out after {preview_timeout} seconds.",
                     )
                 columns = payload.get("columns", [])
                 serialized_rows = payload.get("rows", [])
             else:
                 columns, rows = execute_sql(sql, limit=PREVIEW_LIMIT)
                 serialized_rows = list(serialize_rows(rows))
+        except HTTPException:
+            raise
         except ValueError as err:
             return (
                 jsonify({"ok": False, "error": str(err)}),

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/routes.py
@@ -25,7 +25,7 @@ from qhana_plugin_runner.tasks import save_task_error, save_task_result
 from .plugin import SQL_BLP, SQLEditor
 from .schemas import SQLInputSchema
 from .tasks import preview_sql, process_sql
-from .util import PREVIEW_LIMIT, execute_sql, serialize_rows, validate_sql
+from .util import PREVIEW_LIMIT, execute_sql, serialize_rows
 
 
 @SQL_BLP.route("/")
@@ -103,12 +103,6 @@ class SQLFrontend(MethodView):
             abort(HTTPStatus.INTERNAL_SERVER_ERROR)
 
         render_errors = dict(errors) if errors else {}
-        sql_value = (data.get("sql") or "").strip()
-        if sql_value and "sql" not in render_errors:
-            sql_error = validate_sql(sql_value)
-            if sql_error:
-                render_errors.setdefault("sql", []).append(sql_error)
-                valid = False
 
         schema = SQLInputSchema()
         return Response(

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/schemas.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/schemas.py
@@ -1,0 +1,21 @@
+# Copyright 2025 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import marshmallow as ma
+
+from qhana_plugin_runner.api.util import FrontendFormBaseSchema
+
+
+class SQLInputSchema(FrontendFormBaseSchema):
+    sql = ma.fields.String()

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/schemas.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/schemas.py
@@ -18,4 +18,21 @@ from qhana_plugin_runner.api.util import FrontendFormBaseSchema
 
 
 class SQLInputSchema(FrontendFormBaseSchema):
-    sql = ma.fields.String()
+    sql = ma.fields.String(
+        required=True,
+        metadata={
+            "label": "SQL Command",
+            "description": "DuckDB SQL query to execute.",
+            "input_type": "textarea",
+        },
+    )
+    output_format = ma.fields.String(
+        missing="csv",
+        validate=ma.validate.OneOf(("csv", "json")),
+        metadata={
+            "label": "Output Format",
+            "description": "Format of the output data.",
+            "input_type": "select",
+            "options": {"csv": "CSV", "json": "JSON"},
+        },
+    )

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/schemas.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/schemas.py
@@ -16,14 +16,32 @@ import marshmallow as ma
 
 from qhana_plugin_runner.api.util import FrontendFormBaseSchema
 
+from .util import validate_sql
+
+
+def _validate_sql(value: str) -> None:
+    error = validate_sql(value)
+    if error:
+        raise ma.ValidationError(error)
+
 
 class SQLInputSchema(FrontendFormBaseSchema):
     sql = ma.fields.String(
         required=True,
+        validate=_validate_sql,
         metadata={
             "label": "SQL Command",
             "description": "DuckDB SQL query to execute.",
             "input_type": "textarea",
+        },
+    )
+    output_data_type = ma.fields.String(
+        missing="entity/list",
+        validate=ma.validate.Regexp(r"^[A-Za-z0-9_./*-]+$"),
+        metadata={
+            "label": "Output Data Type",
+            "description": "Data type metadata for the output file.",
+            "input_type": "text",
         },
     )
     output_format = ma.fields.String(

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/tasks.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/tasks.py
@@ -1,12 +1,17 @@
-from typing import Literal, Optional
+import csv
+import json
+from json import loads
+from tempfile import SpooledTemporaryFile
+from typing import Optional
 
 from celery.utils.log import get_task_logger
-from flask.globals import current_app
-from requests import request
 
 from qhana_plugin_runner.celery import CELERY
+from qhana_plugin_runner.db.models.tasks import ProcessingTask
+from qhana_plugin_runner.storage import STORE
 
 from . import plugin
+from .util import execute_sql, rows_to_records, serialize_rows
 
 TASK_LOGGER = get_task_logger(__name__)
 
@@ -16,5 +21,46 @@ TASK_LOGGER = get_task_logger(__name__)
     bind=True,
     ignore_result=True,
 )
-def process_sql(self):
-    pass
+def process_sql(self, db_id: int) -> str:
+    TASK_LOGGER.info(f"Starting new SQL editor task with db id '{db_id}'")
+    task_data: Optional[ProcessingTask] = ProcessingTask.get_by_id(id_=db_id)
+    if task_data is None:
+        msg = f"Could not load task data with id {db_id} to read parameters!"
+        TASK_LOGGER.error(msg)
+        raise KeyError(msg)
+
+    params = loads(task_data.parameters or "{}")
+    sql = params.get("sql", "")
+    output_format = params.get("output_format", "csv")
+
+    columns, rows = execute_sql(sql)
+    file_name = "sql_result.csv"
+    data_type = "entity/list"
+    if output_format == "json":
+        file_name = "sql_result.json"
+
+    with SpooledTemporaryFile(mode="w", newline="") as output:
+        if output_format == "json":
+            json.dump(
+                rows_to_records(columns, rows),
+                output,
+                ensure_ascii=True,
+                default=str,
+            )
+            content_type = "application/json"
+        else:
+            writer = csv.writer(output)
+            writer.writerow(columns)
+            writer.writerows(serialize_rows(rows))
+            content_type = "text/csv"
+
+        output.seek(0)
+        STORE.persist_task_result(
+            db_id,
+            output,
+            file_name,
+            data_type,
+            content_type,
+        )
+
+    return f"Result stored in {file_name}"

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/tasks.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/tasks.py
@@ -1,0 +1,20 @@
+from typing import Literal, Optional
+
+from celery.utils.log import get_task_logger
+from flask.globals import current_app
+from requests import request
+
+from qhana_plugin_runner.celery import CELERY
+
+from . import plugin
+
+TASK_LOGGER = get_task_logger(__name__)
+
+
+@CELERY.task(
+    name=f"{plugin.SQLEditor.instance.identifier}.process_sql",
+    bind=True,
+    ignore_result=True,
+)
+def process_sql(self):
+    pass

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/tasks.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/tasks.py
@@ -56,9 +56,7 @@ def process_sql(self, db_id: int) -> str:
     params = loads(task_data.parameters or "{}")
     sql = params.get("sql", "")
     output_format = params.get("output_format", "csv")
-    output_data_type = (params.get("output_data_type") or "entity/list").strip()
-    if not output_data_type:
-        output_data_type = "entity/list"
+    output_data_type = (params.get("output_data_type", "entity/list")).strip()
 
     columns, rows = execute_sql(sql)
     file_name = "sql_result.csv"

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/tasks.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/tasks.py
@@ -16,6 +16,29 @@ from .util import execute_sql, rows_to_records, serialize_rows
 TASK_LOGGER = get_task_logger(__name__)
 
 
+def _write_json_records(output, records) -> None:
+    output.write("[")
+    first = True
+    for record in records:
+        if first:
+            first = False
+        else:
+            output.write(",")
+        output.write(json.dumps(record, ensure_ascii=True, default=str))
+    output.write("]")
+
+
+@CELERY.task(
+    name=f"{plugin.SQLEditor.instance.identifier}.preview_sql",
+    bind=True,
+    ignore_result=False,
+)
+def preview_sql(self, sql: str, limit: int) -> dict:
+    """Execute a limited SQL query for preview purposes."""
+    columns, rows = execute_sql(sql, limit=limit)
+    return {"columns": columns, "rows": list(serialize_rows(rows))}
+
+
 @CELERY.task(
     name=f"{plugin.SQLEditor.instance.identifier}.process_sql",
     bind=True,
@@ -33,21 +56,19 @@ def process_sql(self, db_id: int) -> str:
     params = loads(task_data.parameters or "{}")
     sql = params.get("sql", "")
     output_format = params.get("output_format", "csv")
+    output_data_type = (params.get("output_data_type") or "entity/list").strip()
+    if not output_data_type:
+        output_data_type = "entity/list"
 
     columns, rows = execute_sql(sql)
     file_name = "sql_result.csv"
-    data_type = "entity/list"
+    data_type = output_data_type
     if output_format == "json":
         file_name = "sql_result.json"
 
     with SpooledTemporaryFile(mode="w", newline="") as output:
         if output_format == "json":
-            json.dump(
-                rows_to_records(columns, rows),
-                output,
-                ensure_ascii=True,
-                default=str,
-            )
+            _write_json_records(output, rows_to_records(columns, rows))
             content_type = "application/json"
         else:
             writer = csv.writer(output)

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/tasks.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/tasks.py
@@ -22,6 +22,7 @@ TASK_LOGGER = get_task_logger(__name__)
     ignore_result=True,
 )
 def process_sql(self, db_id: int) -> str:
+    """Execute the stored SQL query and persist results in the chosen format."""
     TASK_LOGGER.info(f"Starting new SQL editor task with db id '{db_id}'")
     task_data: Optional[ProcessingTask] = ProcessingTask.get_by_id(id_=db_id)
     if task_data is None:

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
@@ -8,6 +8,19 @@
         min-height: 6lh;
         field-sizing: content;
     }
+
+    .suggestion-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.3em;
+    }
+
+    .suggestion-chip {
+        border-radius: 500px;
+        border: none;
+        padding-block: 0.3em;
+        padding-inline: 0.8em;
+    }
 </style>
 {% endblock head %}
 
@@ -18,10 +31,27 @@
         <div class="qhana-form-field">
             <label class="qhana-form-label" for="input_sql">SQL Command</label>
             <div class="qhana-input-wrapper">
-                <textarea class="qhana-form-input" name="sql" id="input_sql" autocomplete="off" required spellcheck="false"></textarea>
+                <textarea class="qhana-form-input" name="sql" id="input_sql" autocomplete="off" aria-describedby="input_sql-description" required spellcheck="false"></textarea>
             </div>
-            <div id="input_str-description" class="qhana-input-description">
-                <p>TODO: Description</p>
+            <div id="input_sql-description" class="qhana-input-description">
+                <p>
+                    Execute an SQL Command using the DuckDB SQL Enging.
+                    Consult the <a target="_blank" referrerpolicy="no-referrer" href="https://duckdb.org/docs/stable/sql/introduction#querying-a-table">DuckDB manual</a> for more information.
+                </p>
+            </div>
+            <div class="suggestion-list">
+                <button class="suggestion-chip" data-suggestion="DESCRIBE ">DESCRIBE …</button>
+                <button class="suggestion-chip" data-suggestion="SELECT * FROM ">SELECT</button>
+                <button class="suggestion-chip" data-suggestion="SELECT DISTINKT * FROM ">SELECT DISTINCT</button>
+                <button class="suggestion-chip" data-suggestion="read_csv('http://') AS table_a">read_csv(…)</button>
+                <button class="suggestion-chip" data-suggestion="read_json('http://') AS table_a">read_json(…)</button>
+                <button class="suggestion-chip" data-suggestion="USING SAMPLE 10">SAMPLE</button>
+                <button class="suggestion-chip" data-suggestion="INNER JOIN  ON  = ">JOIN (matching only)</button>
+                <button class="suggestion-chip" data-suggestion="LEFT OUTER JOIN  ON  = ">JOIN (keep left)</button>
+                <button class="suggestion-chip" data-suggestion="WHERE ">WHERE</button>
+                <button class="suggestion-chip" data-suggestion="ORDER BY ">ORDER BY</button>
+                <button class="suggestion-chip" data-suggestion="DESC">DESC</button>
+                <button class="suggestion-chip" data-suggestion="LIMIT 10">LIMIT</button>
             </div>
         </div>
         <div class="qhana-form-buttons">
@@ -39,7 +69,6 @@
 {{ super() }}
 
 <script>
-    // TODO
     function customSubmitHandler(event) {
         const form = event.target;
         const submitter = event.submitter;
@@ -58,11 +87,31 @@
         return false; // event not handled, use default handling
     }
 
+    function onSuggestionClick(event) {
+        event.preventDefault();
+
+        /** @type {HTMLButtonElement} */
+        const button = event.target;
+        const suggestion = button.dataset.suggestion;
+
+        /** @type {HTMLTextAreaElement} */
+        const sqlInput = document.querySelector("textarea#input_sql");
+
+        if (suggestion) {
+            sqlInput.focus();
+            sqlInput.setRangeText(suggestion, sqlInput.selectionStart, sqlInput.selectionEnd, "end");
+        }
+    }
+
     if (window._qhana_microfrontend_state != null) {
         window._qhana_microfrontend_state.formSubmitHandler = customSubmitHandler;
     } else {
         document.querySelector("form#form_sql").addEventListener("submit", customSubmitHandler);
     }
+
+    document.querySelectorAll("button[data-suggestion]").forEach(button => {
+        button.addEventListener("click", onSuggestionClick);
+    });
 </script>
 
 {% endblock script %}

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
@@ -4,15 +4,34 @@
 {{ super() }}
 <style>
     /* TODO */
+    textarea#input_sql {
+        min-height: 6lh;
+        field-sizing: content;
+    }
 </style>
 {% endblock head %}
 
 {% block content %}
 <div>
-    <div>Input Selection</div>
-    <div>SQL Input</div>
-    <div>SQL Help</div>
-    <div>Output Preview</div>
+    <div>TODO: Input Selection</div>
+    <form id="form_sql" action="" method="post" data-target="check" class="qhana-form" enctype="multipart/form-data">
+        <div class="qhana-form-field">
+            <label class="qhana-form-label" for="input_sql">SQL Command</label>
+            <div class="qhana-input-wrapper">
+                <textarea class="qhana-form-input" name="sql" id="input_sql" autocomplete="off" required spellcheck="false"></textarea>
+            </div>
+            <div id="input_str-description" class="qhana-input-description">
+                <p>TODO: Description</p>
+            </div>
+        </div>
+        <div class="qhana-form-buttons">
+            <button class="qhana-form-submit" type="submit" data-target="check">check sql</button>
+            <button class="qhana-form-submit" type="submit" data-target="preview">try out</button>
+            <button class="qhana-form-submit" type="submit" data-target="api" formaction="{{process}}">submit</button>
+        </div>
+    </form>
+    <div>TODO: SQL Help</div>
+    <div>TODO: Output Preview</div>
 </div>
 {% endblock content %}
 
@@ -21,6 +40,29 @@
 
 <script>
     // TODO
+    function customSubmitHandler(event) {
+        const form = event.target;
+        const submitter = event.submitter;
+        let submitTarget = submitter.getAttribute("data-target") || form.getAttribute("data-target");
+        console.log("SUBMIT", submitTarget);
+        if (submitTarget === "check") {
+            // TODO implement
+            event.preventDefault();
+            return true;
+        }
+        if (submitTarget === "preview") {
+            // TODO implement
+            event.preventDefault();
+            return true;
+        }
+        return false; // event not handled, use default handling
+    }
+
+    if (window._qhana_microfrontend_state != null) {
+        window._qhana_microfrontend_state.formSubmitHandler = customSubmitHandler;
+    } else {
+        document.querySelector("form#form_sql").addEventListener("submit", customSubmitHandler);
+    }
 </script>
 
 {% endblock script %}

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
@@ -21,6 +21,25 @@
         padding-block: 0.3em;
         padding-inline: 0.8em;
     }
+
+    #sql_preview {
+        max-height: 24rem;
+        overflow: auto;
+        margin-top: 0.5rem;
+    }
+
+    #sql_preview table {
+        border-collapse: collapse;
+        width: 100%;
+    }
+
+    #sql_preview th,
+    #sql_preview td {
+        border: 1px solid #ccc;
+        padding: 0.2em 0.4em;
+        text-align: left;
+        font-size: 0.95em;
+    }
 </style>
 {% endblock head %}
 
@@ -31,13 +50,23 @@
         <ul id="data_sources"></ul>
         <button id="add_data_source" class="qhana-choose-file-button">Select from Experiment</button>
     </div>
-    <form id="form_sql" action="" method="post" data-target="check" class="qhana-form" enctype="multipart/form-data">
+    <form id="form_sql" action="" method="post" data-target="check" class="qhana-form" enctype="multipart/form-data"
+          data-check-url="{{check}}" data-preview-url="{{preview}}">
         <div class="qhana-form-field">
             <label class="qhana-form-label" for="input_sql">SQL Command</label>
             <div class="qhana-input-wrapper">
                 <textarea class="qhana-form-input" name="sql" id="input_sql" autocomplete="off" aria-describedby="input_sql-description" required spellcheck="false"></textarea>
             </div>
             <div id="input_sql-description" class="qhana-input-description">
+                {% set sql_errors = errors.get("sql") if errors else None %}
+                <p id="sql_error" class="qhana-error-message" aria-live="assertive" {% if not sql_errors %}hidden{% endif %}>
+                    {% if sql_errors %}
+                        {% for message in sql_errors %}
+                        <span>{{message}}</span>
+                        {% endfor %}
+                    {% endif %}
+                </p>
+                <p id="sql_success" aria-live="polite" hidden>SQL looks valid.</p>
                 <p>
                     Execute an SQL Command using the DuckDB SQL Enging.
                     Consult the <a target="_blank" referrerpolicy="no-referrer" href="https://duckdb.org/docs/stable/sql/introduction#querying-a-table">DuckDB manual</a> for more information.
@@ -58,14 +87,28 @@
                 <button class="suggestion-chip" data-suggestion="LIMIT 10">LIMIT</button>
             </div>
         </div>
+        <div class="qhana-form-field">
+            <label class="qhana-form-label" for="output_format">Output Format</label>
+            <div class="qhana-input-wrapper">
+                <select class="qhana-form-input" name="output_format" id="output_format" autocomplete="off">
+                    <option value="csv" {% if values.get("output_format", "csv") == "csv" %}selected{% endif %}>CSV</option>
+                    <option value="json" {% if values.get("output_format") == "json" %}selected{% endif %}>JSON</option>
+                </select>
+            </div>
+            <div id="output_format-description" class="qhana-input-description">
+                <p>Choose the output format written by the processing task.</p>
+            </div>
+        </div>
         <div class="qhana-form-buttons">
             <button class="qhana-form-submit" type="submit" data-target="check">check sql</button>
             <button class="qhana-form-submit" type="submit" data-target="preview">try out</button>
             <button class="qhana-form-submit" type="submit" data-target="api" formaction="{{process}}">submit</button>
         </div>
     </form>
-    <div>TODO: SQL Help</div>
-    <div>TODO: Output Preview</div>
+    <div>
+        <h2>Output Preview</h2>
+        <div id="sql_preview" class="qhana-data-preview qhana-table" hidden></div>
+    </div>
 </div>
 {% endblock content %}
 
@@ -73,19 +116,149 @@
 {{ super() }}
 
 <script>
+    const sqlError = document.querySelector("#sql_error");
+    const sqlSuccess = document.querySelector("#sql_success");
+    const previewContainer = document.querySelector("#sql_preview");
+
+    function clearStatus() {
+        if (sqlError) {
+            sqlError.textContent = "";
+            sqlError.setAttribute("hidden", "hidden");
+        }
+        if (sqlSuccess) {
+            sqlSuccess.setAttribute("hidden", "hidden");
+        }
+    }
+
+    function showError(message) {
+        if (sqlError) {
+            sqlError.textContent = message;
+            sqlError.removeAttribute("hidden");
+        }
+        if (sqlSuccess) {
+            sqlSuccess.setAttribute("hidden", "hidden");
+        }
+    }
+
+    function showSuccess(message) {
+        if (sqlSuccess) {
+            sqlSuccess.textContent = message;
+            sqlSuccess.removeAttribute("hidden");
+        }
+        if (sqlError) {
+            sqlError.setAttribute("hidden", "hidden");
+        }
+    }
+
+    function clearPreview() {
+        if (!previewContainer) {
+            return;
+        }
+        previewContainer.replaceChildren();
+        previewContainer.setAttribute("hidden", "hidden");
+    }
+
+    function renderPreview(columns, rows, truncated) {
+        if (!previewContainer) {
+            return;
+        }
+        previewContainer.replaceChildren();
+        if (!columns || columns.length === 0) {
+            previewContainer.textContent = "No columns returned.";
+            previewContainer.removeAttribute("hidden");
+            return;
+        }
+        const table = document.createElement("table");
+        const headerRow = document.createElement("tr");
+        columns.forEach(column => {
+            const th = document.createElement("th");
+            th.textContent = column;
+            headerRow.appendChild(th);
+        });
+        table.appendChild(headerRow);
+        rows.forEach(row => {
+            const tr = document.createElement("tr");
+            row.forEach(cell => {
+                const td = document.createElement("td");
+                td.textContent = cell == null ? "" : String(cell);
+                tr.appendChild(td);
+            });
+            table.appendChild(tr);
+        });
+        previewContainer.appendChild(table);
+        if (truncated) {
+            const note = document.createElement("p");
+            note.textContent = `Preview limited to ${rows.length} rows.`;
+            previewContainer.appendChild(note);
+        }
+        previewContainer.removeAttribute("hidden");
+        if (window._qhana_microfrontend_state != null) {
+            monitorHeightChanges(window._qhana_microfrontend_state);
+        }
+    }
+
+    async function postForm(form, url) {
+        const response = await fetch(url, {
+            method: "POST",
+            body: new FormData(form),
+        });
+        let payload = {};
+        try {
+            payload = await response.json();
+        } catch (err) {
+            payload = {};
+        }
+        if (!response.ok || payload.ok === false) {
+            const message = payload.error || payload.message || "Request failed.";
+            throw new Error(message);
+        }
+        return payload;
+    }
+
+    async function handleCheck(form) {
+        const url = form.dataset.checkUrl;
+        if (!url) {
+            showError("Check endpoint is not configured.");
+            return;
+        }
+        clearPreview();
+        clearStatus();
+        try {
+            await postForm(form, url);
+            showSuccess("SQL looks valid.");
+        } catch (err) {
+            showError(err.message);
+        }
+    }
+
+    async function handlePreview(form) {
+        const url = form.dataset.previewUrl;
+        if (!url) {
+            showError("Preview endpoint is not configured.");
+            return;
+        }
+        clearStatus();
+        try {
+            const payload = await postForm(form, url);
+            renderPreview(payload.columns, payload.rows, payload.truncated);
+        } catch (err) {
+            clearPreview();
+            showError(err.message);
+        }
+    }
+
     function customSubmitHandler(event) {
         const form = event.target;
         const submitter = event.submitter;
-        let submitTarget = submitter.getAttribute("data-target") || form.getAttribute("data-target");
-        console.log("SUBMIT", submitTarget);
+        const submitTarget = submitter?.getAttribute("data-target") || form.getAttribute("data-target");
         if (submitTarget === "check") {
-            // TODO implement
             event.preventDefault();
+            handleCheck(form);
             return true;
         }
         if (submitTarget === "preview") {
-            // TODO implement
             event.preventDefault();
+            handlePreview(form);
             return true;
         }
         return false; // event not handled, use default handling

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
@@ -102,20 +102,34 @@
         <div class="qhana-form-field">
             <label class="qhana-form-label" for="output_data_type">Output Data Type</label>
             <div class="qhana-input-wrapper">
-                <select class="qhana-form-input" name="outputDataType" id="output_data_type" autocomplete="off">
-                    <option value="entity/list" {% if values.get("outputDataType", "entity/list") == "entity/list" %}selected{% endif %}>entity/list</option>
-                    <option value="entity/vector" {% if values.get("outputDataType") == "entity/vector" %}selected{% endif %}>entity/vector</option>
-                    <option value="entity/matrix" {% if values.get("outputDataType") == "entity/matrix" %}selected{% endif %}>entity/matrix</option>
-                    <option value="entity/attribute-metadata" {% if values.get("outputDataType") == "entity/attribute-metadata" %}selected{% endif %}>entity/attribute-metadata</option>
-                    <option value="custom/attribute-similarities" {% if values.get("outputDataType") == "custom/attribute-similarities" %}selected{% endif %}>custom/attribute-similarities</option>
-                    <option value="custom/attribute-distances" {% if values.get("outputDataType") == "custom/attribute-distances" %}selected{% endif %}>custom/attribute-distances</option>
-                    <option value="custom/entity-distances" {% if values.get("outputDataType") == "custom/entity-distances" %}selected{% endif %}>custom/entity-distances</option>
-                    <option value="graph/taxonomy" {% if values.get("outputDataType") == "graph/taxonomy" %}selected{% endif %}>graph/taxonomy</option>
-                    <option value="*" {% if values.get("outputDataType") == "*" %}selected{% endif %}>*</option>
-                </select>
+                <input
+                    class="qhana-form-input"
+                    type="text"
+                    name="outputDataType"
+                    id="output_data_type"
+                    list="output_data_type_suggestions"
+                    pattern="[A-Za-z0-9_./*-]+"
+                    value="{{ values.get('outputDataType', 'entity/list') }}"
+                    autocomplete="off"
+                    required
+                >
+                <datalist id="output_data_type_suggestions">
+                    <option value="entity/list">
+                    <option value="entity/vector">
+                    <option value="entity/matrix">
+                    <option value="entity/attribute-metadata">
+                    <option value="custom/attribute-similarities">
+                    <option value="custom/attribute-distances">
+                    <option value="custom/entity-distances">
+                    <option value="graph/taxonomy">
+                    <option value="*">
+                </datalist>
             </div>
             <div id="output_data_type-description" class="qhana-input-description">
-                <p>Override the output data type metadata if needed for downstream plugins.</p>
+                <p>
+                    Override the output data type metadata if needed for downstream plugins.
+                    Custom values are allowed.
+                </p>
             </div>
         </div>
         <div class="qhana-form-buttons">

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
@@ -1,0 +1,26 @@
+{% extends "simple_template.html" %}
+
+{% block head %}
+{{ super() }}
+<style>
+    /* TODO */
+</style>
+{% endblock head %}
+
+{% block content %}
+<div>
+    <div>Input Selection</div>
+    <div>SQL Input</div>
+    <div>SQL Help</div>
+    <div>Output Preview</div>
+</div>
+{% endblock content %}
+
+{% block script %}
+{{ super() }}
+
+<script>
+    // TODO
+</script>
+
+{% endblock script %}

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
@@ -26,7 +26,11 @@
 
 {% block content %}
 <div>
-    <div>TODO: Input Selection</div>
+    <div>
+        <h2>Data Sources</h2>
+        <ul id="data_sources"></ul>
+        <button id="add_data_source" class="qhana-choose-file-button">Select from Experiment</button>
+    </div>
     <form id="form_sql" action="" method="post" data-target="check" class="qhana-form" enctype="multipart/form-data">
         <div class="qhana-form-field">
             <label class="qhana-form-label" for="input_sql">SQL Command</label>
@@ -87,6 +91,16 @@
         return false; // event not handled, use default handling
     }
 
+    function onChooseNewDataSource(event) {
+        event.preventDefault();
+        sendMessage({
+            type: "request-data-url",
+            inputKey: "dataSource",
+            acceptedInputType: "*",
+            acceptedContentTypes: ["text/csv", "application/json"], // TODO: check against duckdb
+        });
+    }
+
     function onSuggestionClick(event) {
         event.preventDefault();
 
@@ -103,11 +117,110 @@
         }
     }
 
+    function onDataUrlResponse(message) {
+        if (message.inputKey !== "dataSource") {
+            return;
+        }
+
+        const exisitngEntries = Array.from(document.querySelectorAll(`ul#data_sources li[data-url]`));
+        if (exisitngEntries.some(li => li.dataset.url === message.href)) {
+            return;  // data source already added
+        }
+
+        const test = {
+            "type": "data-url-response",
+            "inputKey": "",
+            "href": "",
+            "dataType": "entity/list",
+            "contentType": "text/csv",
+            "filename": "test.csv",
+            "version": "v1"
+        }
+        const urlStatement = `'${message.href}'`;
+
+        /** @type {string} */
+        let tableName = message.filename;
+        if (tableName.includes(".")) {
+            tableName = tableName.substring(0, tableName.indexOf("."));
+        }
+        tableName = tableName.replace(/[^a-zA-Z]/g, "");
+
+        let tableStatement;
+        let tableStatementShort;
+        if (message.contentType === "text/csv") {
+            tableStatement = `read_csv(${urlStatement}) AS ${tableName}`;
+            tableStatementShort = "read_csv(…)";
+        } else if (message.contentType === "application/json") {
+            tableStatement = `read_json(${urlStatement}) AS ${tableName}`;
+            tableStatementShort = "read_json(…)";
+        } else {
+            console.log(`Unsupported content type ${message.contentType}.`, message);
+            return;
+        }
+
+        const selectStatement = `SELECT * FROM ${tableStatement}`;
+
+        const container = document.createElement("li");
+        container.dataset.url = message.href;
+        container.dataset.filename = message.filename;
+        container.dataset.version = message.version;
+        container.dataset.dataType = message.dataType;
+        container.dataset.contentType = message.contentType;
+
+        const header = document.createElement("p");
+        container.appendChild(header);
+        header.textContent = `${message.filename} (${message.version}) – ${message.dataType}; ${message.contentType}`;
+
+        const buttonList = document.createElement("div");
+        container.appendChild(buttonList);
+        buttonList.classList.add("suggestion-list");
+
+        const selectBtn = document.createElement("button");
+        buttonList.appendChild(selectBtn);
+        selectBtn.classList.add("suggestion-chip");
+        selectBtn.dataset.suggestion = selectStatement;
+        selectBtn.textContent = "SELECT …";
+        selectBtn.addEventListener("click", onSuggestionClick);
+
+        const tableBtn = document.createElement("button");
+        buttonList.appendChild(tableBtn);
+        tableBtn.classList.add("suggestion-chip");
+        tableBtn.dataset.suggestion = tableStatement;
+        tableBtn.textContent = tableStatementShort;
+        tableBtn.addEventListener("click", onSuggestionClick);
+
+        const urlBtn = document.createElement("button");
+        buttonList.appendChild(urlBtn);
+        urlBtn.classList.add("suggestion-chip");
+        urlBtn.dataset.suggestion = urlStatement;
+        urlBtn.textContent = "'http://…'";
+        urlBtn.addEventListener("click", onSuggestionClick);
+
+        document.querySelector("ul#data_sources").appendChild(container);
+
+        if (window._qhana_microfrontend_state != null) {
+            // height has changed, notify parent
+            monitorHeightChanges(window._qhana_microfrontend_state);
+        }
+    }
+
+    function messageInterceptor(event) {
+        var data = event.data;
+        if ((typeof data !== "string") && (data != null && data.type === "data-url-response")) {
+            onDataUrlResponse(data);
+            return true;
+        }
+        return false; // message event not handled, use default handling
+    }
+
     if (window._qhana_microfrontend_state != null) {
         window._qhana_microfrontend_state.formSubmitHandler = customSubmitHandler;
+        window._qhana_microfrontend_state.messageHandler = messageInterceptor;
     } else {
         document.querySelector("form#form_sql").addEventListener("submit", customSubmitHandler);
     }
+
+    document.querySelector("button#add_data_source").addEventListener("click", onChooseNewDataSource);
 
     document.querySelectorAll("button[data-suggestion]").forEach(button => {
         button.addEventListener("click", onSuggestionClick);

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/templates/sql-editor.html
@@ -3,8 +3,8 @@
 {% block head %}
 {{ super() }}
 <style>
-    /* TODO */
     textarea#input_sql {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
         min-height: 6lh;
         field-sizing: content;
     }
@@ -90,13 +90,32 @@
         <div class="qhana-form-field">
             <label class="qhana-form-label" for="output_format">Output Format</label>
             <div class="qhana-input-wrapper">
-                <select class="qhana-form-input" name="output_format" id="output_format" autocomplete="off">
-                    <option value="csv" {% if values.get("output_format", "csv") == "csv" %}selected{% endif %}>CSV</option>
-                    <option value="json" {% if values.get("output_format") == "json" %}selected{% endif %}>JSON</option>
+                <select class="qhana-form-input" name="outputFormat" id="output_format" autocomplete="off">
+                    <option value="csv" {% if values.get("outputFormat", "csv") == "csv" %}selected{% endif %}>CSV</option>
+                    <option value="json" {% if values.get("outputFormat") == "json" %}selected{% endif %}>JSON</option>
                 </select>
             </div>
             <div id="output_format-description" class="qhana-input-description">
                 <p>Choose the output format written by the processing task.</p>
+            </div>
+        </div>
+        <div class="qhana-form-field">
+            <label class="qhana-form-label" for="output_data_type">Output Data Type</label>
+            <div class="qhana-input-wrapper">
+                <select class="qhana-form-input" name="outputDataType" id="output_data_type" autocomplete="off">
+                    <option value="entity/list" {% if values.get("outputDataType", "entity/list") == "entity/list" %}selected{% endif %}>entity/list</option>
+                    <option value="entity/vector" {% if values.get("outputDataType") == "entity/vector" %}selected{% endif %}>entity/vector</option>
+                    <option value="entity/matrix" {% if values.get("outputDataType") == "entity/matrix" %}selected{% endif %}>entity/matrix</option>
+                    <option value="entity/attribute-metadata" {% if values.get("outputDataType") == "entity/attribute-metadata" %}selected{% endif %}>entity/attribute-metadata</option>
+                    <option value="custom/attribute-similarities" {% if values.get("outputDataType") == "custom/attribute-similarities" %}selected{% endif %}>custom/attribute-similarities</option>
+                    <option value="custom/attribute-distances" {% if values.get("outputDataType") == "custom/attribute-distances" %}selected{% endif %}>custom/attribute-distances</option>
+                    <option value="custom/entity-distances" {% if values.get("outputDataType") == "custom/entity-distances" %}selected{% endif %}>custom/entity-distances</option>
+                    <option value="graph/taxonomy" {% if values.get("outputDataType") == "graph/taxonomy" %}selected{% endif %}>graph/taxonomy</option>
+                    <option value="*" {% if values.get("outputDataType") == "*" %}selected{% endif %}>*</option>
+                </select>
+            </div>
+            <div id="output_data_type-description" class="qhana-input-description">
+                <p>Override the output data type metadata if needed for downstream plugins.</p>
             </div>
         </div>
         <div class="qhana-form-buttons">
@@ -197,6 +216,45 @@
         }
     }
 
+    function getFirstError(errors) {
+        if (!errors || typeof errors !== "object") {
+            return null;
+        }
+        for (const key of Object.keys(errors)) {
+            const value = errors[key];
+            if (Array.isArray(value) && value.length > 0) {
+                return value[0];
+            }
+            if (typeof value === "string") {
+                return value;
+            }
+            if (value && typeof value === "object") {
+                const nested = getFirstError(value);
+                if (nested) {
+                    return nested;
+                }
+            }
+        }
+        return null;
+    }
+
+    function getErrorMessage(payload) {
+        if (!payload) {
+            return "Request failed.";
+        }
+        if (payload.error) {
+            return payload.error;
+        }
+        const nestedError = getFirstError(payload.errors);
+        if (nestedError) {
+            return nestedError;
+        }
+        if (payload.message) {
+            return payload.message;
+        }
+        return "Request failed.";
+    }
+
     async function postForm(form, url) {
         const response = await fetch(url, {
             method: "POST",
@@ -209,8 +267,7 @@
             payload = {};
         }
         if (!response.ok || payload.ok === false) {
-            const message = payload.error || payload.message || "Request failed.";
-            throw new Error(message);
+            throw new Error(getErrorMessage(payload));
         }
         return payload;
     }
@@ -270,7 +327,7 @@
             type: "request-data-url",
             inputKey: "dataSource",
             acceptedInputType: "*",
-            acceptedContentTypes: ["text/csv", "application/json"], // TODO: check against duckdb
+            acceptedContentTypes: ["text/csv", "application/json"],
         });
     }
 

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
@@ -85,11 +85,6 @@ def validate_sql(sql: str) -> str | None:
     return error
 
 
-def check_sql_syntax(sql: str) -> str | None:
-    """Return a user-facing error message for invalid SQL, else None."""
-    return validate_sql(sql)
-
-
 def _prepare_connection(con: duckdb.DuckDBPyConnection) -> None:
     """Enable HTTP(S) reads by loading DuckDB's httpfs extension."""
     try:

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
@@ -1,0 +1,21 @@
+import duckdb
+
+
+def execute_sql(sql: str):
+    with duckdb.connect(
+        config={
+            "python_enable_replacements": False,
+            "allow_community_extensions": False,
+            "allow_persistent_secrets": False,
+            # "disabled_filesystems": "LocalFileSystem",
+        }
+    ) as con:
+        con.install_extension("httpfs")
+        con.load_extension("httpfs")
+        result = con.sql(sql)
+        print(result)
+        print(result.fetchall())
+
+
+if __name__ == "__main__":
+    execute_sql("SELECT 42;")

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
@@ -19,6 +19,7 @@ PRAGMA_PATTERN = re.compile(r"^pragma\s+([a-z_]+)\b", re.IGNORECASE)
 
 
 def normalize_sql(sql: str) -> str:
+    """Normalize SQL input by trimming whitespace and trailing semicolons."""
     normalized = (sql or "").strip()
     while normalized.endswith(";"):
         normalized = normalized[:-1].rstrip()
@@ -26,6 +27,7 @@ def normalize_sql(sql: str) -> str:
 
 
 def strip_leading_comments(sql: str) -> str:
+    """Remove leading line/block comments to inspect the actual statement."""
     stripped = sql.lstrip()
     while True:
         if stripped.startswith("--"):
@@ -46,6 +48,7 @@ def strip_leading_comments(sql: str) -> str:
 # Security hardening without restricting access in duckdb
 # TBD whether enough or not
 def validate_pragma(sql: str) -> str | None:
+    """Allow only whitelisted, read-only PRAGMA statements."""
     match = PRAGMA_PATTERN.match(sql)
     if not match:
         return None
@@ -56,7 +59,7 @@ def validate_pragma(sql: str) -> str | None:
 
 
 def validate_sql(sql: str) -> tuple[str | None, str]:
-    """Validate SQL syntax and enforce basic safety checks."""
+    """Parse SQL and enforce single-statement, read-only policy."""
     normalized = normalize_sql(sql)
     if not normalized:
         return "SQL query is required.", normalized
@@ -76,11 +79,13 @@ def validate_sql(sql: str) -> tuple[str | None, str]:
 
 
 def check_sql_syntax(sql: str) -> str | None:
+    """Return a user-facing error message for invalid SQL, else None."""
     error, _ = validate_sql(sql)
     return error
 
 
 def _prepare_connection(con: duckdb.DuckDBPyConnection) -> None:
+    """Enable HTTP(S) reads by loading DuckDB's httpfs extension."""
     try:
         con.install_extension("httpfs")
     except duckdb.Error:
@@ -95,6 +100,7 @@ def _prepare_connection(con: duckdb.DuckDBPyConnection) -> None:
 
 
 def execute_sql(sql: str, *, limit: int | None = None) -> tuple[list[str], list[tuple]]:
+    """Run validated SQL and return column names plus result rows."""
     error, normalized = validate_sql(sql)
     if error:
         raise ValueError(error)
@@ -106,7 +112,8 @@ def execute_sql(sql: str, *, limit: int | None = None) -> tuple[list[str], list[
             # "disabled_filesystems": "LocalFileSystem",
         }
     ) as con:
-        # FIXME: https://duckdb.org/docs/stable/operations_manual/securing_duckdb/overview
+        # FIXME: https://duckdb.org/docs/stable/operations_manual/
+        # securing_duckdb/overview
         _prepare_connection(con)
         relation = con.sql(normalized)
         if limit is not None:
@@ -117,6 +124,7 @@ def execute_sql(sql: str, *, limit: int | None = None) -> tuple[list[str], list[
 
 
 def serialize_value(value):
+    """Convert result values into JSON-safe primitives."""
     if isinstance(value, (datetime, date)):
         return value.isoformat()
     if isinstance(value, Decimal):
@@ -127,10 +135,12 @@ def serialize_value(value):
 
 
 def serialize_rows(rows: Iterable[tuple]) -> list[list]:
+    """Serialize an iterable of rows into JSON-friendly lists."""
     return [[serialize_value(value) for value in row] for row in rows]
 
 
 def rows_to_records(columns: list[str], rows: Iterable[tuple]) -> list[dict]:
+    """Map result rows to dict records keyed by column name."""
     return [
         {column: serialize_value(value) for column, value in zip(columns, row)}
         for row in rows

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
@@ -149,6 +149,4 @@ def serialize_rows(rows: Iterable[tuple]) -> Iterable[list]:
 def rows_to_records(columns: list[str], rows: Iterable[tuple]) -> Iterable[dict]:
     """Map result rows to dict records keyed by column name."""
     for row in rows:
-        yield {
-            column: serialize_value(value) for column, value in zip(columns, row)
-        }
+        yield {column: serialize_value(value) for column, value in zip(columns, row)}

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
@@ -1,16 +1,103 @@
+from __future__ import annotations
+
+import re
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Iterable
+
 import duckdb
 
+PREVIEW_LIMIT = 100
+ALLOWED_STATEMENT_TYPES = {duckdb.StatementType.SELECT}
+READ_ONLY_PRAGMAS = {
+    "show_tables",
+    "show_databases",
+    "show_schemas",
+    "table_info",
+}
+PRAGMA_PATTERN = re.compile(r"^pragma\s+([a-z_]+)\b", re.IGNORECASE)
 
-def check_sql_syntax(sql: str) -> str | None:
-    try:
-        # workaround to only check SQL for syntax errors without executing it
-        duckdb.extract_statements(sql)
-    except duckdb.ParserException as err:
-        return err.args[0]
+
+def normalize_sql(sql: str) -> str:
+    normalized = (sql or "").strip()
+    while normalized.endswith(";"):
+        normalized = normalized[:-1].rstrip()
+    return normalized
+
+
+def strip_leading_comments(sql: str) -> str:
+    stripped = sql.lstrip()
+    while True:
+        if stripped.startswith("--"):
+            newline = stripped.find("\n")
+            if newline == -1:
+                return ""
+            stripped = stripped[newline + 1 :].lstrip()
+            continue
+        if stripped.startswith("/*"):
+            end = stripped.find("*/")
+            if end == -1:
+                return ""
+            stripped = stripped[end + 2 :].lstrip()
+            continue
+        return stripped
+
+
+# Security hardening without restricting access in duckdb
+# TBD whether enough or not
+def validate_pragma(sql: str) -> str | None:
+    match = PRAGMA_PATTERN.match(sql)
+    if not match:
+        return None
+    pragma_name = match.group(1).lower()
+    if pragma_name not in READ_ONLY_PRAGMAS:
+        return f"PRAGMA '{pragma_name}' is not allowed."
     return None
 
 
-def execute_sql(sql: str):
+def validate_sql(sql: str) -> tuple[str | None, str]:
+    """Validate SQL syntax and enforce basic safety checks."""
+    normalized = normalize_sql(sql)
+    if not normalized:
+        return "SQL query is required.", normalized
+    pragma_error = validate_pragma(strip_leading_comments(normalized))
+    if pragma_error:
+        return pragma_error, normalized
+    try:
+        statements = duckdb.extract_statements(normalized)
+    except duckdb.ParserException as err:
+        return err.args[0], normalized
+    if len(statements) != 1:
+        return "Only a single SQL statement is allowed.", normalized
+    statement = statements[0]
+    if statement.type not in ALLOWED_STATEMENT_TYPES:
+        return "Only SELECT statements are allowed.", normalized
+    return None, normalized
+
+
+def check_sql_syntax(sql: str) -> str | None:
+    error, _ = validate_sql(sql)
+    return error
+
+
+def _prepare_connection(con: duckdb.DuckDBPyConnection) -> None:
+    try:
+        con.install_extension("httpfs")
+    except duckdb.Error:
+        # Extension may already be installed or installation may be unavailable.
+        pass
+    try:
+        con.load_extension("httpfs")
+    except duckdb.Error as err:
+        raise RuntimeError(
+            "Failed to load DuckDB httpfs extension required for HTTP(S) sources."
+        ) from err
+
+
+def execute_sql(sql: str, *, limit: int | None = None) -> tuple[list[str], list[tuple]]:
+    error, normalized = validate_sql(sql)
+    if error:
+        raise ValueError(error)
     with duckdb.connect(
         config={
             "python_enable_replacements": False,
@@ -20,13 +107,31 @@ def execute_sql(sql: str):
         }
     ) as con:
         # FIXME: https://duckdb.org/docs/stable/operations_manual/securing_duckdb/overview
-        con.install_extension("httpfs")
-        con.load_extension("httpfs")
-        result = con.sql(sql)
-        print(result)
-        print(result.fetchall())
+        _prepare_connection(con)
+        relation = con.sql(normalized)
+        if limit is not None:
+            relation = relation.limit(limit)
+        columns = relation.columns
+        rows = relation.fetchall()
+    return columns, rows
 
 
-if __name__ == "__main__":
-    print(check_sql_syntax("SELLLECT 42;"))
-    execute_sql("SELECT 42;")
+def serialize_value(value):
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def serialize_rows(rows: Iterable[tuple]) -> list[list]:
+    return [[serialize_value(value) for value in row] for row in rows]
+
+
+def rows_to_records(columns: list[str], rows: Iterable[tuple]) -> list[dict]:
+    return [
+        {column: serialize_value(value) for column, value in zip(columns, row)}
+        for row in rows
+    ]

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
@@ -1,6 +1,15 @@
 import duckdb
 
 
+def check_sql_syntax(sql: str) -> str | None:
+    try:
+        # workaround to only check SQL for syntax errors without executing it
+        duckdb.extract_statements(sql)
+    except duckdb.ParserException as err:
+        return err.args[0]
+    return None
+
+
 def execute_sql(sql: str):
     with duckdb.connect(
         config={
@@ -18,4 +27,5 @@ def execute_sql(sql: str):
 
 
 if __name__ == "__main__":
+    print(check_sql_syntax("SELLLECT 42;"))
     execute_sql("SELECT 42;")

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
@@ -19,6 +19,7 @@ def execute_sql(sql: str):
             # "disabled_filesystems": "LocalFileSystem",
         }
     ) as con:
+        # FIXME: https://duckdb.org/docs/stable/operations_manual/securing_duckdb/overview
         con.install_extension("httpfs")
         con.load_extension("httpfs")
         result = con.sql(sql)

--- a/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
+++ b/stable_plugins/classical_ml/data_preparation/sql_editor/util.py
@@ -58,7 +58,8 @@ def validate_pragma(sql: str) -> str | None:
     return None
 
 
-def validate_sql(sql: str) -> tuple[str | None, str]:
+# This helper normalizes SQL while validating it for read-only usage.
+def _normalize_and_validate_sql(sql: str) -> tuple[str | None, str]:
     """Parse SQL and enforce single-statement, read-only policy."""
     normalized = normalize_sql(sql)
     if not normalized:
@@ -78,10 +79,15 @@ def validate_sql(sql: str) -> tuple[str | None, str]:
     return None, normalized
 
 
+def validate_sql(sql: str) -> str | None:
+    """Return a user-facing error message for invalid SQL, else None."""
+    error, _ = _normalize_and_validate_sql(sql)
+    return error
+
+
 def check_sql_syntax(sql: str) -> str | None:
     """Return a user-facing error message for invalid SQL, else None."""
-    error, _ = validate_sql(sql)
-    return error
+    return validate_sql(sql)
 
 
 def _prepare_connection(con: duckdb.DuckDBPyConnection) -> None:
@@ -101,7 +107,7 @@ def _prepare_connection(con: duckdb.DuckDBPyConnection) -> None:
 
 def execute_sql(sql: str, *, limit: int | None = None) -> tuple[list[str], list[tuple]]:
     """Run validated SQL and return column names plus result rows."""
-    error, normalized = validate_sql(sql)
+    error, normalized = _normalize_and_validate_sql(sql)
     if error:
         raise ValueError(error)
     with duckdb.connect(
@@ -134,14 +140,15 @@ def serialize_value(value):
     return value
 
 
-def serialize_rows(rows: Iterable[tuple]) -> list[list]:
-    """Serialize an iterable of rows into JSON-friendly lists."""
-    return [[serialize_value(value) for value in row] for row in rows]
+def serialize_rows(rows: Iterable[tuple]) -> Iterable[list]:
+    """Serialize rows into JSON-friendly lists as a generator."""
+    for row in rows:
+        yield [serialize_value(value) for value in row]
 
 
-def rows_to_records(columns: list[str], rows: Iterable[tuple]) -> list[dict]:
+def rows_to_records(columns: list[str], rows: Iterable[tuple]) -> Iterable[dict]:
     """Map result rows to dict records keyed by column name."""
-    return [
-        {column: serialize_value(value) for column, value in zip(columns, row)}
-        for row in rows
-    ]
+    for row in rows:
+        yield {
+            column: serialize_value(value) for column, value in zip(columns, row)
+        }


### PR DESCRIPTION
Add a Plugin that can process any csv/json data using SQL statements (e.g. to join or filter existing data).

- [x] Plugin skeleton
- [x] Utility functions to execute SQL using data from external CSV or JSON (e.g. hosted by the QHAna backend)
- [ ] Basic security sanity checks
- [x] Basic UI (select inputs, input SQL, try out/commit)
- [ ] Advanced UI (SQL help, autocomplete?!)
- [x] connect UI to backend

Backend
- [x] Process API endpoint implementation
- [x] Process SQL task (output csv or json entities)
- [x] check SQL endpoint
- [x] check SQL syntax in microfrontend endpoint
- [x] try out SQL endpoint (maybe as part of normal process endpoint with a Flag, maybe inject SAMPLING into query to limit results)