### PR TITLE
Example tests for data_creator plugin

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,6 +17,8 @@ jobs:
         run: pipx install poetry
       - name: Install dependencies
         run: poetry install --no-interaction --with dev
+      - name: Install plugin dependencies (only plugins with tests)
+        run: poetry run flask install --only-with-tests --skip-runner-dependencies
       - name: Run pytest
         run: poetry run pytest --cov=qhana_plugin_runner --cov-report=html --cov-report=term
       - name: Upload coverage report

--- a/conftest.py
+++ b/conftest.py
@@ -15,19 +15,17 @@
 """Tests for the db module of the plugin_utils."""
 
 from logging import INFO
+
 import pytest
-from dotenv import load_dotenv
-
-load_dotenv(".flaskenv")
-load_dotenv(".env")
-
-MODULE_NAME = "qhana_plugin_runner"
-
+from flask import Flask
 
 from qhana_plugin_runner import create_app
 from qhana_plugin_runner.db.cli import create_db_function
 from qhana_plugin_runner.db.models.tasks import ProcessingTask
 from qhana_plugin_runner.util.config.celery_config import CELERY_PRODUCTION_CONFIG
+
+MODULE_NAME = "qhana_plugin_runner"
+
 
 DEFAULT_TEST_CONFIG = {
     "SECRET_KEY": "test",
@@ -44,6 +42,9 @@ DEFAULT_TEST_CONFIG = {
     "OPENAPI_VERSION": "3.0.2",
     "OPENAPI_JSON_PATH": "api-spec.json",
     "OPENAPI_URL_PREFIX": "",
+    # ``SERVER_NAME`` lets ``flask.url_for`` build URLs without a request
+    # context, which the route-level tests in plugin test suites rely on.
+    "SERVER_NAME": "localhost.localdomain",
 }
 
 
@@ -59,3 +60,27 @@ def task_data():
         task_data = ProcessingTask(task_name="test-data")
         task_data.save(commit=True)
         yield task_data
+
+
+@pytest.fixture(scope="module")
+def app():
+    """Flask app with the plugin runner and all configured plugins loaded.
+
+    ``create_app`` discovers plugins from ``PLUGIN_FOLDERS`` (set in
+    ``.flaskenv``), so every plugin blueprint is registered automatically
+    once this fixture runs. Module-scoped to amortise the boot cost across
+    test cases in a file.
+    """
+    test_config = dict(DEFAULT_TEST_CONFIG)
+    test_config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+
+    flask_app = create_app(test_config)
+    with flask_app.app_context():
+        create_db_function(flask_app)
+        yield flask_app
+
+
+@pytest.fixture()
+def client(app: Flask):
+    """Flask test client bound to the plugin-runner app."""
+    return app.test_client()

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -104,9 +104,13 @@ The fixture is function-scoped, so each test gets a fresh database.
 The ``app`` and ``client`` fixtures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``app`` is a module-scoped Flask application built via :py:func:`~qhana_plugin_runner.create_app` with the same in-memory SQLite configuration as ``task_data``. Plugin discovery runs as part of ``create_app``, so every blueprint declared under ``PLUGIN_FOLDERS`` is registered on the returned app. Module scope amortises the startup cost of plugin discovery across the test cases in a file. Use ``app`` whenever a test needs the full configured application, an application context, or :py:func:`flask.url_for` without a request context (the test configuration sets ``SERVER_NAME`` so ``url_for`` can build URLs outside a request).
+``app`` is a module-scoped Flask application built via :py:func:`~qhana_plugin_runner.create_app` with the same in-memory SQLite configuration as ``task_data``.
+Plugin discovery runs as part of ``create_app``, so every blueprint declared under ``PLUGIN_FOLDERS`` is registered on the returned app.
+Module scope amortises the startup cost of plugin discovery across the test cases in a file.
+Use ``app`` whenever a test needs the full configured application, an application context, or :py:func:`flask.url_for` without a request context (the test configuration sets ``SERVER_NAME`` so ``url_for`` can build URLs outside a request).
 
-``client`` is a function-scoped :py:meth:`flask.Flask.test_client` bound to ``app``. It is the standard entry point for HTTP-level tests and removes the need for a plugin-local Flask fixture:
+``client`` is a function-scoped :py:meth:`flask.Flask.test_client` bound to ``app``.
+It is the standard entry point for HTTP-level tests and removes the need for a plugin-local Flask fixture:
 
 .. code-block:: python
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -101,6 +101,25 @@ The ``task_data`` fixture
 
 The fixture is function-scoped, so each test gets a fresh database.
 
+The ``app`` and ``client`` fixtures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``app`` is a module-scoped Flask application built via :py:func:`~qhana_plugin_runner.create_app` with the same in-memory SQLite configuration as ``task_data``. Plugin discovery runs as part of ``create_app``, so every blueprint declared under ``PLUGIN_FOLDERS`` is registered on the returned app. Module scope amortises the startup cost of plugin discovery across the test cases in a file. Use ``app`` whenever a test needs the full configured application, an application context, or :py:func:`flask.url_for` without a request context (the test configuration sets ``SERVER_NAME`` so ``url_for`` can build URLs outside a request).
+
+``client`` is a function-scoped :py:meth:`flask.Flask.test_client` bound to ``app``. It is the standard entry point for HTTP-level tests and removes the need for a plugin-local Flask fixture:
+
+.. code-block:: python
+
+    from http import HTTPStatus
+    from flask import url_for
+
+
+    def test_metadata_endpoint(client):
+        response = client.get(url_for("data-creator-v0-1-1.PluginsView"))
+        assert response.status_code == HTTPStatus.OK
+
+Both fixtures are defined in the repo-root :source:`conftest.py` and are auto-discovered.
+
 Assertion helpers in ``tests/utils.py``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -137,6 +156,21 @@ To test a plugin:
 3. Plugin source files **must use relative imports** (this is enforced by ``tests/test_plugin_imports.py`` so plugins remain relocatable, see :doc:`plugins`). Test files are excluded from this check, so plugin tests can use absolute imports.
 
 Test module names can collide across plugins (multiple plugins each having a ``test_routes.py`` is fine). ``--import-mode=importlib`` handles the disambiguation.
+
+Examples
+~~~~~~~~
+
+The :source:`stable_plugins/data_synthesis/data_creator/tests/` directory demonstrates the test types described in this guide. It uses the nested layout and relies on the ``client`` fixture from the repo-root :source:`conftest.py`. Each file covers one aspect of the plugin:
+
+* :source:`stable_plugins/data_synthesis/data_creator/tests/test_datasets.py`  
+
+  Pure unit tests and hypothesis property tests for the numpy-based dataset generators in :source:`stable_plugins/data_synthesis/data_creator/backend/datasets.py`. Demonstrates :py:func:`pytest.mark.parametrize` for shape checks across every ``DataTypeEnum`` member, and ``@given`` strategies for invariants (output length, finite values, integer label dtype, label range bounded by ``centers``). No fixtures are required because the generators have no Flask, DB, or Celery dependencies.
+* :source:`stable_plugins/data_synthesis/data_creator/tests/test_schemas.py`
+
+  Marshmallow schema tests for ``InputParametersSchema``. Covers the round-trip from JSON payload to ``InputParameters`` dataclass (including the ``camelCase`` rewriting performed by ``MaBaseSchema``), the per-type required-field rules in ``REQUIRED_FIELDS_BY_TYPE``, range validators on ``num_train_points`` / ``noise`` / ``turns`` / ``centers``, and rejection of unknown ``dataset_type`` values. Schemas are pure Python, so these tests also run without a Flask app.
+* :source:`stable_plugins/data_synthesis/data_creator/tests/test_routes.py`
+
+  HTTP-level tests using the shared ``client`` fixture. Covers the metadata endpoint (``GET /plugins/<id>/``), the micro frontend form rendering and default values, and the form's behavior on invalid input (the route uses ``validate_errors_as_result=True`` and re-renders rather than returning a 400). The ``/process/`` endpoint enqueues a Celery task and is therefore covered by Celery-aware tests instead, see :doc:`adr/0018-celery-task-testing-strategy`.
 
 For Celery tasks specifically, follow the pattern below.
 
@@ -274,6 +308,7 @@ See also
 * :doc:`adr/0006-use-celery-task-queue`
 * :doc:`adr/0018-celery-task-testing-strategy`
 * :doc:`adr/0019-co-locate-plugin-tests`
+* :source:`stable_plugins/data_synthesis/data_creator/tests/`, an example covering unit, property-based, schema, and route tests for a stable plugin.
 * :doc:`plugins`, the plugin authoring guide.
 * `pytest documentation <https://docs.pytest.org/>`_
 * `hypothesis documentation <https://hypothesis.readthedocs.io/>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ target-version = ["py310"]
 line-length = 90
 include = '\.pyi?$'
 
+[tool.ruff]
+  line-length = 90
+
 [tool.isort]
 profile = "black"
 multi_line_output = 3

--- a/qhana_plugin_runner/plugins_cli.py
+++ b/qhana_plugin_runner/plugins_cli.py
@@ -19,7 +19,7 @@ from io import TextIOWrapper
 from pathlib import Path
 from subprocess import PIPE, CalledProcessError, run
 from tempfile import TemporaryDirectory
-from typing import cast
+from typing import Optional, cast
 
 import click
 from flask import Blueprint, Flask, current_app
@@ -50,9 +50,17 @@ PLUGIN_COMMAND_LOGGER = "plugins"
     is_flag=True,
     help="Only add the requirements of the plugins together skipping the requirements of the plugin runner.",
 )
+@click.option(
+    "--only-with-tests",
+    default=False,
+    is_flag=True,
+    help="Only install requirements for plugins whose source directory contains test files.",
+)
 @PLUGIN_CLI.command("install")
 @with_appcontext
-def install_plugin_dependencies(dry_run: bool, skip_runner_dependencies: bool):
+def install_plugin_dependencies(
+    dry_run: bool, skip_runner_dependencies: bool, only_with_tests: bool
+):
     """Gather and install all plugin dependencies."""
     with TemporaryDirectory(prefix="qhana") as temp_dir:
         temp_dir = Path(temp_dir)
@@ -61,6 +69,8 @@ def install_plugin_dependencies(dry_run: bool, skip_runner_dependencies: bool):
             if not skip_runner_dependencies:
                 append_runner_dependencies(current_app, requirements)
             for plugin in QHAnaPluginBase.get_plugins().values():
+                if only_with_tests and not _plugin_has_tests(plugin):
+                    continue
                 append_plugin_dependencies(plugin, current_app, requirements)
         if dry_run:
             with requirements_file.open() as r:
@@ -125,3 +135,13 @@ def register_plugin_cli_blueprint(app: Flask):
     """Method to register the plugins CLI blueprint."""
     app.register_blueprint(PLUGIN_CLI_BLP)
     app.logger.info("Registered plugin cli blueprint.")
+
+
+def _plugin_has_tests(plugin: QHAnaPluginBase) -> bool:
+    """Return True if the plugin's source directory contains any test_*.py files."""
+    module = sys.modules.get(type(plugin).__module__)
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        return False
+    plugin_dir = Path(module_file).resolve().parent
+    return any(plugin_dir.rglob("test_*.py"))

--- a/stable_plugins/data_synthesis/data_creator/__init__.py
+++ b/stable_plugins/data_synthesis/data_creator/__init__.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from typing import Optional
 
 from flask import Flask
 
 from qhana_plugin_runner.api.util import SecurityBlueprint
 from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
-from pathlib import Path
-
 
 _plugin_name = "data-creator"
 __version__ = "v0.2.3"
@@ -48,7 +47,7 @@ class DataCreator(QHAnaPluginBase):
         return DataCreator_BLP
 
     def get_requirements(self) -> str:
-        return "numpy~=1.13"
+        return "numpy~=1.13\nscikit-learn~=1.1"
 
 
 try:

--- a/stable_plugins/data_synthesis/data_creator/backend/datasets.py
+++ b/stable_plugins/data_synthesis/data_creator/backend/datasets.py
@@ -14,9 +14,9 @@
 
 from enum import Enum
 from typing import List, Tuple
-from sklearn.datasets import make_blobs
 
 import numpy as np
+from sklearn.datasets import make_blobs
 
 
 class DataTypeEnum(Enum):
@@ -81,7 +81,7 @@ def checkerboard(n_points: int, **kwargs) -> Tuple[np.ndarray, np.ndarray]:
 
 
 # Creates Gaussian blobs for clusering using sckit-learns make_blobs
-def blobs(n_points: int, centers: int, **kwargs) -> Tuple[np.ndarray, np.ndarray]:
+def blobs(n_points: int, centers: int = 4, **kwargs) -> Tuple[np.ndarray, np.ndarray]:
     """Returns the Blobs dataset."""
     x, y = make_blobs(
         n_samples=n_points,
@@ -110,7 +110,7 @@ def checkerboard_3d(n_points: int, **kwargs) -> Tuple[np.ndarray, np.ndarray]:
 
 
 # Creates 3D Gaussian blobs for clusering using sckit-learns make_blobs
-def blobs_3d(n_points: int, centers: int, **kwargs) -> Tuple[np.ndarray, np.ndarray]:
+def blobs_3d(n_points: int, centers: int = 4, **kwargs) -> Tuple[np.ndarray, np.ndarray]:
     """Returns the 3D Blobs dataset."""
     x, y = make_blobs(
         n_samples=n_points,

--- a/stable_plugins/data_synthesis/data_creator/schemas.py
+++ b/stable_plugins/data_synthesis/data_creator/schemas.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
 
 import marshmallow as ma
-from marshmallow import post_load
+from marshmallow import ValidationError, post_load, validate, validates_schema
 
 from qhana_plugin_runner.api.extra_fields import EnumField
 from qhana_plugin_runner.api.util import (
@@ -24,6 +25,14 @@ from qhana_plugin_runner.api.util import (
 )
 
 from .backend.datasets import DataTypeEnum
+
+REQUIRED_FIELDS_BY_TYPE: dict[DataTypeEnum, frozenset[str]] = {
+    DataTypeEnum.two_spirals: frozenset({"noise", "turns"}),
+    DataTypeEnum.checkerboard: frozenset(),  # Empty set => only the shared fields are needed.
+    DataTypeEnum.blobs: frozenset({"centers"}),
+    DataTypeEnum.checkerboard_3d: frozenset(),
+    DataTypeEnum.blobs_3d: frozenset({"centers"}),
+}
 
 
 class TaskResponseSchema(MaBaseSchema):
@@ -37,9 +46,9 @@ class InputParameters:
     dataset_type: DataTypeEnum
     num_train_points: int
     num_test_points: int
-    turns: float = None
-    noise: float = None
-    centers: int = None
+    turns: Optional[float] = None
+    noise: Optional[float] = None
+    centers: Optional[int] = None
 
     def __str__(self):
         return str(self.__dict__.copy())
@@ -64,6 +73,7 @@ class InputParametersSchema(FrontendFormBaseSchema):
     num_train_points = ma.fields.Integer(
         required=True,
         allow_none=False,
+        validate=validate.Range(min=1),
         metadata={
             "label": "No. Training Points",
             "description": "Determines the size of the training dataset.",
@@ -71,8 +81,9 @@ class InputParametersSchema(FrontendFormBaseSchema):
         },
     )
     num_test_points = ma.fields.Integer(
-        required=False,
-        allow_none=True,
+        required=True,
+        allow_none=False,
+        validate=validate.Range(min=0),
         metadata={
             "label": "No. Test Points",
             "description": "Determines the size of the test dataset.",
@@ -82,24 +93,27 @@ class InputParametersSchema(FrontendFormBaseSchema):
     noise = ma.fields.Float(
         required=False,
         allow_none=True,
+        validate=validate.Range(min=0),
         metadata={
             "label": "Noise",
             "description": "Gives the dataset creation some noise",
-            "input_type": "text",
+            "input_type": "number",
         },
     )
     turns = ma.fields.Float(
-        required=True,
-        allow_none=False,
+        required=False,
+        allow_none=True,
+        validate=validate.Range(min=0, min_inclusive=False),
         metadata={
             "label": "Turns",
             "description": "Determines the turns of the spiral dataset",
-            "input_type": "text",
+            "input_type": "number",
         },
     )
     centers = ma.fields.Integer(
         required=False,
-        allow_none=False,
+        allow_none=True,
+        validate=validate.Range(min=1),
         metadata={
             "label": "No. Centers",
             "description": "Determines the number of Blobs",
@@ -107,6 +121,26 @@ class InputParametersSchema(FrontendFormBaseSchema):
         },
     )
 
+    @validates_schema
+    def validate_required_for_type(self, data, **kwargs):
+        dataset_type = data.get("dataset_type")
+        if not isinstance(dataset_type, DataTypeEnum):
+            raise ValidationError(
+                {"dataset_type": [f"Unknown dataset type: {dataset_type!r}."]}
+            )
+        required = REQUIRED_FIELDS_BY_TYPE.get(dataset_type, frozenset())
+        missing = {f for f in required if data.get(f) is None}
+        if missing:
+            raise ValidationError(
+                {f: ["Required for selected dataset type."] for f in sorted(missing)}
+            )
+
     @post_load
     def make_input_params(self, data, **kwargs) -> InputParameters:
         return InputParameters(**data)
+
+    if TYPE_CHECKING:
+        # type checking hint for tests in test_schema.py
+        def load(
+            self, data, *, many=None, partial=None, unknown=None
+        ) -> InputParameters: ...

--- a/stable_plugins/data_synthesis/data_creator/templates/data_creator_template.html
+++ b/stable_plugins/data_synthesis/data_creator/templates/data_creator_template.html
@@ -2,27 +2,36 @@
 
 {% block script %}
 <script>
-    var noise_vis = document.getElementById("noise").parentNode.parentNode;
-    var turns_vis = document.getElementById("turns").parentNode.parentNode;
-    var centers_vis = document.getElementById("centers").parentNode.parentNode;
+    var noise_input = document.getElementById("noise");
+    var turns_input = document.getElementById("turns");
+    var centers_input = document.getElementById("centers");
     var dataset_type = document.getElementById("dataset_type");
 
+    // Must match REQUIRED_FIELDS_BY_TYPE in schemas.py
+    var FIELDS_BY_TYPE = {
+        two_spirals: [noise_input, turns_input],
+        checkerboard: [],
+        blobs: [centers_input],
+        checkerboard_3d: [],
+        blobs_3d: [centers_input],
+    };
+    var ALL_INPUTS = [noise_input, turns_input, centers_input];
+
+    function group(input) { return input.parentNode.parentNode; }
+
     function dataset_type_change() {
-        console.log("data_type_change");
-        noise_vis.style.display = 'none';
-        turns_vis.style.display = 'none';
-        centers_vis.style.display = 'none';
-        if (dataset_type.value === "two_spirals") {
-            noise_vis.style.display = 'block';
-            turns_vis.style.display = 'block';
-        }
-        if (dataset_type.value === "blobs" || dataset_type.value === "blobs_3d") {
-            centers_vis.style.display = 'block';
-        }
+        var relevant = FIELDS_BY_TYPE[dataset_type.value] || [];
+        ALL_INPUTS.forEach(function (input) {
+            var visible = relevant.indexOf(input) !== -1;
+            group(input).style.display = visible ? 'block' : 'none';
+            // Disabled inputs don't get submitted, so irrelevant garbage values
+            // can't trip marshmallow field-level validation.
+            input.disabled = !visible;
+        });
     }
 
     dataset_type.addEventListener("change", dataset_type_change);
-    centers_vis.style.display = 'none';
+    dataset_type_change();
 </script>
 {{ super() }}
 {% endblock script %}

--- a/stable_plugins/data_synthesis/data_creator/tests/test_datasets.py
+++ b/stable_plugins/data_synthesis/data_creator/tests/test_datasets.py
@@ -1,0 +1,198 @@
+# Copyright 2026 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit and property-based tests for the data-creator dataset generators.
+
+The dataset generators in :mod:`data_creator.backend.datasets` are pure
+functions on top of numpy and scikit-learn. They have no Flask, database, or
+Celery dependencies, so the tests in this module run as plain pytest cases
+without any fixtures.
+
+Two test styles appear here:
+
+* **Example-driven unit tests** assert the documented contract for a fixed
+  set of inputs (shape, dimensionality, label range).
+* **Property-based tests** with `hypothesis
+  <https://hypothesis.readthedocs.io/>`_ generate many random parameter
+  combinations and check invariants that should hold for every input
+  (output length, label dtype, no NaN or infinity).
+
+The combination catches both regressions in known-good cases and edge cases
+the author did not think of when writing the example-driven tests.
+"""
+
+import numpy as np
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from data_creator.backend.datasets import (
+    DataTypeEnum,
+    blobs,
+    blobs_3d,
+    checkerboard,
+    checkerboard_3d,
+    twospirals,
+)
+
+# Example-driven unit tests.
+
+
+@pytest.mark.parametrize("data_type", list(DataTypeEnum), ids=lambda e: e.name)
+def test_get_data(data_type):
+    """Check ``get_data`` shapes across several ``(n_train, n_test)`` pairs.
+
+    Uses :py:func:`pytest.mark.parametrize` to generate one independent test
+    case per :py:class:`DataTypeEnum` member.
+    """
+    expected_dim = (
+        3 if data_type in {DataTypeEnum.checkerboard_3d, DataTypeEnum.blobs_3d} else 2
+    )
+
+    for n_train, n_test in [(1, 0), (10, 0), (20, 10), (50, 50), (100, 1)]:
+        train_data, train_labels, test_data, test_labels = data_type.get_data(
+            n_train, n_test
+        )
+
+        assert (
+            isinstance(train_data, list)
+            and isinstance(train_labels, list)
+            and isinstance(test_data, list)
+            and isinstance(test_labels, list)
+        )
+        assert len(train_data) == n_train
+        assert len(train_labels) == n_train
+        if data_type is DataTypeEnum.two_spirals:
+            # twospirals mirrors its input, so total = 2*(n_train + n_test)
+            # and the test partition is whatever remains after taking n_train.
+            assert len(test_data) == 2 * (n_train + n_test) - n_train
+            assert len(test_labels) == 2 * (n_train + n_test) - n_train
+        else:
+            assert len(test_data) == n_test
+            assert len(test_labels) == n_test
+        assert len(test_labels) == len(test_data)
+        assert all(len(p) == expected_dim for p in train_data)
+        assert all(len(p) == expected_dim for p in test_data)
+
+
+def test_twospirals_doubles_point_count():
+    """``twospirals`` mirrors each spiral, returning ``2 * n_points`` rows."""
+    np.random.seed(0)
+    data, labels = twospirals(50)
+    assert data.shape == (100, 2)
+    assert labels.shape == (100,)
+
+
+def test_twospirals_labels_are_balanced_binary():
+    """One spiral is labelled ``0``, the mirrored spiral is labelled ``1``."""
+    np.random.seed(0)
+    _, labels = twospirals(50)
+    assert set(np.unique(labels).tolist()) == {0, 1}
+    assert int((labels == 0).sum()) == 50
+    assert int((labels == 1).sum()) == 50
+
+
+def test_checkerboard_shape_and_labels():
+    np.random.seed(0)
+    data, labels = checkerboard(80)
+    assert data.shape == (80, 2)
+    assert set(np.unique(labels).tolist()).issubset({0, 1})
+
+
+def test_checkerboard_pushes_points_off_axes():
+    """The generator nudges every point at least ``0.2`` away from each axis."""
+    np.random.seed(0)
+    data, _ = checkerboard(100)
+    assert np.all(np.abs(data) >= 0.2)
+
+
+def test_blobs_label_range_matches_centers():
+    np.random.seed(0)
+    data, labels = blobs(60, centers=3)
+    assert data.shape == (60, 2)
+    assert set(np.unique(labels).tolist()) == {0, 1, 2}
+
+
+def test_checkerboard_3d_returns_three_features():
+    np.random.seed(0)
+    data, labels = checkerboard_3d(40)
+    assert data.shape == (40, 3)
+    assert set(np.unique(labels).tolist()).issubset({0, 1})
+
+
+def test_blobs_3d_returns_three_features():
+    np.random.seed(0)
+    data, labels = blobs_3d(60, centers=2)
+    assert data.shape == (60, 3)
+    assert set(np.unique(labels).tolist()) == {0, 1}
+
+
+# Property-based tests.
+
+# Strategies. Bounds are chosen to keep generation fast and to avoid degenerate
+# cases (zero points, NaN-producing turns) that the production code is not
+# expected to handle.
+_n_points = st.integers(min_value=1, max_value=50)
+_noise = st.floats(min_value=0.0, max_value=2.0, allow_nan=False, allow_infinity=False)
+_turns = st.floats(min_value=0.1, max_value=5.0, allow_nan=False, allow_infinity=False)
+_centers = st.integers(min_value=1, max_value=8)
+
+
+@given(n=_n_points, noise=_noise, turns=_turns)
+def test_twospirals_invariants(n, noise, turns):
+    """For any valid parameters, ``twospirals`` returns ``2*n`` finite 2D points."""
+    data, labels = twospirals(n, noise=noise, turns=turns)
+    assert data.shape == (2 * n, 2)
+    assert labels.shape == (2 * n,)
+    assert np.all(np.isfinite(data))
+    assert np.issubdtype(labels.dtype, np.integer)
+
+
+@given(n=_n_points)
+def test_checkerboard_invariants(n):
+    data, labels = checkerboard(n)
+    assert data.shape == (n, 2)
+    assert labels.shape == (n,)
+    assert np.all(np.isfinite(data))
+    assert np.issubdtype(labels.dtype, np.integer)
+    assert set(np.unique(labels).tolist()).issubset({0, 1})
+
+
+@given(n=_n_points, centers=_centers)
+def test_blobs_invariants(n, centers):
+    data, labels = blobs(n, centers=centers)
+    assert data.shape == (n, 2)
+    assert labels.shape == (n,)
+    assert np.all(np.isfinite(data))
+    assert np.issubdtype(labels.dtype, np.integer)
+    assert int(labels.min()) >= 0
+    assert int(labels.max()) < centers
+
+
+@given(n=_n_points)
+def test_checkerboard_3d_invariants(n):
+    data, labels = checkerboard_3d(n)
+    assert data.shape == (n, 3)
+    assert labels.shape == (n,)
+    assert np.all(np.isfinite(data))
+    assert set(np.unique(labels).tolist()).issubset({0, 1})
+
+
+@given(n=_n_points, centers=_centers)
+def test_blobs_3d_invariants(n, centers):
+    data, labels = blobs_3d(n, centers=centers)
+    assert data.shape == (n, 3)
+    assert labels.shape == (n,)
+    assert np.all(np.isfinite(data))
+    assert int(labels.max()) < centers

--- a/stable_plugins/data_synthesis/data_creator/tests/test_routes.py
+++ b/stable_plugins/data_synthesis/data_creator/tests/test_routes.py
@@ -1,0 +1,110 @@
+# Copyright 2026 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HTTP-level tests for the data-creator plugin routes.
+
+These tests use the Flask test client provided by the local ``client``
+fixture to hit the plugin's metadata endpoint and the micro frontend without
+starting a real server. The ``/process/`` endpoint enqueues a Celery task
+and is therefore covered by Celery-aware tests instead (see
+:doc:`adr/0018-celery-task-testing-strategy`); it is intentionally skipped
+here.
+"""
+
+import re
+from http import HTTPStatus
+
+from flask import url_for
+
+from data_creator import DataCreator, DataCreator_BLP
+
+
+def test_metadata_endpoint_returns_plugin_descriptor(client):
+    """``GET /plugins/<id>/`` returns the plugin metadata as JSON."""
+    response = client.get(url_for(f"{DataCreator_BLP.name}.PluginsView"))
+
+    assert response.status_code == HTTPStatus.OK
+    body = response.get_json()
+    assert body["name"] == DataCreator.instance.name
+    assert body["version"] == DataCreator.instance.version
+    assert body["title"] == "Data Creation"
+    assert "data-loading" in body["tags"]
+
+
+def test_metadata_endpoint_describes_four_outputs(client):
+    """The data-creator entry point declares four outputs: train/test x data/labels.
+
+    The plugin runner schemas serialize python ``snake_case`` field names as
+    ``camelCase`` in JSON (see :py:class:`MaBaseSchema`), so the keys read
+    here are ``entryPoint``, ``dataOutput``, ``dataType`` and ``contentType``.
+    """
+    response = client.get(url_for(f"{DataCreator_BLP.name}.PluginsView"))
+    outputs = response.get_json()["entryPoint"]["dataOutput"]
+
+    assert len(outputs) == 4
+    data_types = [out["dataType"] for out in outputs]
+    assert data_types.count("entity/vector") == 2
+    assert data_types.count("entity/label") == 2
+    for out in outputs:
+        assert "application/json" in out["contentType"]
+
+
+def test_microfrontend_renders_form_fields(client):
+    """``GET /ui/`` returns an HTML form populated with the schema's labels."""
+    response = client.get(url_for(f"{DataCreator_BLP.name}.MicroFrontend"))
+
+    assert response.status_code == HTTPStatus.OK
+    body = response.get_data(as_text=True)
+    # The form labels match the ``metadata["label"]`` strings declared on
+    # ``InputParametersSchema``. If those labels change, this test should be
+    # updated to follow.
+    assert "Dataset Type" in body
+    assert "No. Training Points" in body
+    assert "No. Test Points" in body
+
+
+def test_microfrontend_shows_default_values(client):
+    """The frontend pre-fills the optional fields with the documented defaults."""
+    response = client.get(url_for(f"{DataCreator_BLP.name}.MicroFrontend"))
+    body = response.get_data(as_text=True)
+
+    # Defaults set in routes.py: noise=0.7, turns=1.52, centers=4. Bind the
+    # value to the specific input via ``name="..."`` so an unrelated occurrence
+    # of "4" elsewhere in the rendered HTML cannot make the assertion pass.
+    for field, expected in (("noise", "0.7"), ("turns", "1.52"), ("centers", "4")):
+        pattern = rf'name="{field}"[^>]*value="{re.escape(expected)}"'
+        input_pattern = rf'<input[^>]*name="{field}"[^>]*>'
+        matches = re.findall(input_pattern, body)
+        assert re.search(
+            pattern, body
+        ), f"input {field!r} should default to {expected!r}; got: {matches}"
+
+
+def test_microfrontend_rejects_invalid_post(client):
+    """Posting an invalid payload re-renders the form with errors instead of 400.
+
+    The route uses ``validate_errors_as_result=True``, which means schema
+    errors are passed to the view as a dict rather than aborting the request.
+    The test verifies the form still renders 200 and that the invalid value
+    is accepted as a string in the rendered HTML (so the user can correct it).
+    """
+    response = client.post(
+        url_for(f"{DataCreator_BLP.name}.MicroFrontend"),
+        data={
+            "dataset_type": "not-a-real-dataset",
+            "num_train_points": "abc",
+            "turns": "1.5",
+        },
+    )
+    assert response.status_code == HTTPStatus.OK

--- a/stable_plugins/data_synthesis/data_creator/tests/test_schemas.py
+++ b/stable_plugins/data_synthesis/data_creator/tests/test_schemas.py
@@ -1,0 +1,270 @@
+# Copyright 2026 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Schema validation tests for the data-creator plugin.
+
+``InputParametersSchema`` is a marshmallow schema that
+
+* uses :py:class:`~qhana_plugin_runner.api.extra_fields.EnumField` to bind a
+  string payload value to a member of :py:class:`DataTypeEnum`,
+* uses :py:meth:`marshmallow.post_load` to convert the dict into an
+  :py:class:`InputParameters` dataclass,
+* marks ``dataset_type``, ``num_train_points`` and ``num_test_points`` as
+  required, plus per-type required fields enforced via ``@validates_schema``
+  (see ``REQUIRED_FIELDS_BY_TYPE``).
+
+The tests here exercise each of those behaviors with valid and invalid input.
+They run without a Flask app, since marshmallow schemas are pure Python.
+
+Note: ``MaBaseSchema`` rewrites field names to ``camelCase`` for the JSON
+payload, so the input keys are ``datasetType``, ``numTrainPoints`` etc., even
+though the produced dataclass attributes stay ``snake_case``.
+"""
+
+import pytest
+from marshmallow import ValidationError
+
+from data_creator.backend.datasets import DataTypeEnum
+from data_creator.schemas import (
+    REQUIRED_FIELDS_BY_TYPE,
+    InputParameters,
+    InputParametersSchema,
+)
+
+
+def _payload(dataset_type: str, **overrides) -> dict:
+    """Build a payload with sensible defaults for every shared field."""
+    base = {
+        "datasetType": dataset_type,
+        "numTrainPoints": 10,
+        "numTestPoints": 5,
+    }
+    base.update(overrides)
+    return base
+
+
+# Valid payloads, one per DataTypeEnum variant.
+
+
+def test_two_spirals_valid():
+    schema = InputParametersSchema()
+    result = schema.load(
+        _payload("two_spirals", noise=0.5, turns=1.5),
+    )
+    assert isinstance(result, InputParameters)
+    assert result.dataset_type is DataTypeEnum.two_spirals
+    assert result.num_train_points == 10
+    assert result.num_test_points == 5
+    assert result.noise == 0.5
+    assert result.turns == 1.5
+    assert result.centers is None
+
+
+def test_checkerboard_valid_without_optional_fields():
+    schema = InputParametersSchema()
+    result = schema.load(_payload("checkerboard"))
+    assert result.dataset_type is DataTypeEnum.checkerboard
+    assert result.noise is None
+    assert result.turns is None
+    assert result.centers is None
+
+
+def test_blobs_valid():
+    schema = InputParametersSchema()
+    result = schema.load(_payload("blobs", centers=4))
+    assert result.dataset_type is DataTypeEnum.blobs
+    assert result.centers == 4
+
+
+def test_checkerboard_3d_valid_without_optional_fields():
+    schema = InputParametersSchema()
+    result = schema.load(_payload("checkerboard_3d"))
+    assert result.dataset_type is DataTypeEnum.checkerboard_3d
+
+
+def test_blobs_3d_valid():
+    schema = InputParametersSchema()
+    result = schema.load(_payload("blobs_3d", centers=2))
+    assert result.dataset_type is DataTypeEnum.blobs_3d
+    assert result.centers == 2
+
+
+def test_optional_fields_accepted_for_type_that_does_not_require_them():
+    """``checkerboard`` ignores all per-type optional fields, but the schema
+    still accepts and stores them when supplied."""
+    schema = InputParametersSchema()
+    result = schema.load(
+        _payload("checkerboard", noise=0.1, turns=2.0, centers=3),
+    )
+    assert result.noise == 0.1
+    assert result.turns == 2.0
+    assert result.centers == 3
+
+
+def test_zero_test_points_valid():
+    schema = InputParametersSchema()
+    result = schema.load(_payload("checkerboard", numTestPoints=0))
+    assert result.num_test_points == 0
+
+
+# Per-type required fields.
+
+
+@pytest.mark.parametrize(
+    ("dataset_type", "missing_field"),
+    [
+        ("two_spirals", "noise"),
+        ("two_spirals", "turns"),
+        ("blobs", "centers"),
+        ("blobs_3d", "centers"),
+    ],
+)
+def test_missing_required_field_for_type(dataset_type, missing_field):
+    schema = InputParametersSchema()
+    extras = {"noise": 0.5, "turns": 1.5, "centers": 3}
+    extras.pop(missing_field)
+    with pytest.raises(ValidationError) as exc:
+        schema.load(_payload(dataset_type, **extras))
+    assert missing_field in exc.value.messages
+
+
+def test_two_spirals_missing_both_required_fields_reports_both():
+    schema = InputParametersSchema()
+    with pytest.raises(ValidationError) as exc:
+        schema.load(_payload("two_spirals"))
+    assert {"noise", "turns"}.issubset(exc.value.messages)
+
+
+def test_required_fields_table_covers_every_enum_member():
+    assert set(REQUIRED_FIELDS_BY_TYPE.keys()) == set(DataTypeEnum)
+
+
+# dataset_type validation.
+
+
+def test_unknown_dataset_type_rejected():
+    schema = InputParametersSchema()
+    with pytest.raises(ValidationError) as exc:
+        schema.load(_payload("not_a_real_type"))
+    assert "datasetType" in exc.value.messages
+
+
+def test_dataset_type_required():
+    schema = InputParametersSchema()
+    with pytest.raises(ValidationError) as exc:
+        schema.load({"numTrainPoints": 10, "numTestPoints": 5})
+    assert "datasetType" in exc.value.messages
+
+
+def test_dataset_type_none_rejected():
+    schema = InputParametersSchema()
+    with pytest.raises(ValidationError) as exc:
+        schema.load(_payload(None))
+    assert "datasetType" in exc.value.messages
+
+
+# Shared required fields.
+
+
+def test_num_train_points_required():
+    schema = InputParametersSchema()
+    payload = _payload("checkerboard")
+    payload.pop("numTrainPoints")
+    with pytest.raises(ValidationError) as exc:
+        schema.load(payload)
+    assert "numTrainPoints" in exc.value.messages
+
+
+def test_num_test_points_required():
+    schema = InputParametersSchema()
+    payload = _payload("checkerboard")
+    payload.pop("numTestPoints")
+    with pytest.raises(ValidationError) as exc:
+        schema.load(payload)
+    assert "numTestPoints" in exc.value.messages
+
+
+# Range validators.
+
+
+@pytest.mark.parametrize("value", [0, -1, -100])
+def test_num_train_points_must_be_positive(value):
+    schema = InputParametersSchema()
+    with pytest.raises(ValidationError) as exc:
+        schema.load(_payload("checkerboard", numTrainPoints=value))
+    assert "numTrainPoints" in exc.value.messages
+
+
+@pytest.mark.parametrize("value", [-1, -100])
+def test_num_test_points_must_be_non_negative(value):
+    schema = InputParametersSchema()
+    with pytest.raises(ValidationError) as exc:
+        schema.load(_payload("checkerboard", numTestPoints=value))
+    assert "numTestPoints" in exc.value.messages
+
+
+@pytest.mark.parametrize("value", [-0.1, -1.0])
+def test_noise_must_be_non_negative(value):
+    schema = InputParametersSchema()
+    with pytest.raises(ValidationError) as exc:
+        schema.load(_payload("two_spirals", noise=value, turns=1.5))
+    assert "noise" in exc.value.messages
+
+
+def test_noise_zero_allowed():
+    schema = InputParametersSchema()
+    result = schema.load(_payload("two_spirals", noise=0, turns=1.5))
+    assert result.noise == 0
+
+
+@pytest.mark.parametrize("value", [0, -0.1, -2.0])
+def test_turns_must_be_strictly_positive(value):
+    schema = InputParametersSchema()
+    with pytest.raises(ValidationError) as exc:
+        schema.load(_payload("two_spirals", noise=0.5, turns=value))
+    assert "turns" in exc.value.messages
+
+
+@pytest.mark.parametrize("value", [0, -1])
+def test_centers_must_be_at_least_one(value):
+    schema = InputParametersSchema()
+    with pytest.raises(ValidationError) as exc:
+        schema.load(_payload("blobs", centers=value))
+    assert "centers" in exc.value.messages
+
+
+# Type coercion / serialisation.
+
+
+def test_post_load_returns_dataclass_with_snake_case_attributes():
+    schema = InputParametersSchema()
+    result = schema.load(_payload("blobs", centers=2))
+    assert isinstance(result, InputParameters)
+    assert hasattr(result, "dataset_type")
+    assert hasattr(result, "num_train_points")
+    assert hasattr(result, "num_test_points")
+
+
+def test_str_includes_all_fields():
+    """``InputParameters.__str__`` is used in plugin logging and must surface
+    every field, including the optional ones."""
+    params = InputParameters(
+        dataset_type=DataTypeEnum.blobs,
+        num_train_points=10,
+        num_test_points=5,
+        centers=4,
+    )
+    rendered = str(params)
+    for key in ("dataset_type", "num_train_points", "num_test_points", "centers"):
+        assert key in rendered


### PR DESCRIPTION
- Add tests for datasets, routes, and schemas.
- Schema now validates per-data-type fields (clusters/centers/std for clusters, n_classes for classification, etc.) and template only renders fields relevant to the selected data type.
- CI: Install plugin dependencies (only for plugins that have test files)

Authored with the help of Claude Opus 4.7.

Closes UST-QuAntiL/QHAna4MUSE-EnPro26#23