### PR TITLE
Feature/visualization improvements

### DIFF
--- a/stable_plugins/classical_ml/scikit_ml/classical_k_means/backend/visualize.py
+++ b/stable_plugins/classical_ml/scikit_ml/classical_k_means/backend/visualize.py
@@ -55,12 +55,17 @@ def plot_data(
             hover_name="ID",
             size="size",
             color="label",
+            symbol="label",
         )
     elif dim == 2:
-        fig = px.scatter(df, x="x", y="y", hover_name="ID", size="size", color="label")
+        fig = px.scatter(
+            df, x="x", y="y", hover_name="ID", size="size", color="label", symbol="label"
+        )
     else:
         df["y"] = [0] * len(df["x"])
-        fig = px.scatter(df, x="x", y="y", hover_name="ID", size="size", color="label")
+        fig = px.scatter(
+            df, x="x", y="y", hover_name="ID", size="size", color="label", symbol="label"
+        )
 
     fig.update_layout(
         dict(

--- a/stable_plugins/classical_ml/scikit_ml/classical_k_medoids/backend/visualize.py
+++ b/stable_plugins/classical_ml/scikit_ml/classical_k_medoids/backend/visualize.py
@@ -55,12 +55,17 @@ def plot_data(
             hover_name="ID",
             size="size",
             color="label",
+            symbol="label",
         )
     elif dim == 2:
-        fig = px.scatter(df, x="x", y="y", hover_name="ID", size="size", color="label")
+        fig = px.scatter(
+            df, x="x", y="y", hover_name="ID", size="size", color="label", symbol="label"
+        )
     else:
         df["y"] = [0] * len(df["x"])
-        fig = px.scatter(df, x="x", y="y", hover_name="ID", size="size", color="label")
+        fig = px.scatter(
+            df, x="x", y="y", hover_name="ID", size="size", color="label", symbol="label"
+        )
 
     fig.update_layout(
         dict(

--- a/stable_plugins/classical_ml/scikit_ml/optics-clustering/backend/visualize.py
+++ b/stable_plugins/classical_ml/scikit_ml/optics-clustering/backend/visualize.py
@@ -55,12 +55,17 @@ def plot_data(
             hover_name="ID",
             size="size",
             color="label",
+            symbol="label",
         )
     elif dim == 2:
-        fig = px.scatter(df, x="x", y="y", hover_name="ID", size="size", color="label")
+        fig = px.scatter(
+            df, x="x", y="y", hover_name="ID", size="size", color="label", symbol="label"
+        )
     else:
         df["y"] = [0] * len(df["x"])
-        fig = px.scatter(df, x="x", y="y", hover_name="ID", size="size", color="label")
+        fig = px.scatter(
+            df, x="x", y="y", hover_name="ID", size="size", color="label", symbol="label"
+        )
 
     fig.update_layout(
         dict(

--- a/stable_plugins/visualization/complex/cluster_scatter_visualization/cluster_scatter_visualization_templates/cluster_scatter_visualization.html
+++ b/stable_plugins/visualization/complex/cluster_scatter_visualization/cluster_scatter_visualization_templates/cluster_scatter_visualization.html
@@ -33,6 +33,8 @@
 {% block script %}
 {{ super() }}
 <script>
+    let requestedEntityDataFor = null;
+
     // Resets the iframe without a plot
     function onPlotError() {
         document.querySelector('.cluster-preview').innerHTML = '';
@@ -42,80 +44,46 @@
         }
     }
 
-    function chooseRelatedData(event) {
-        event.preventDefault();
-        const button = event.target;
-        let relatedData;
-        if (button.dataset.inputId === "entity_url") {
-            relatedData = document.querySelector('input[name=clustersUrl]').value;
-        } else if (button.dataset.inputId === "clusters_url") {
-            relatedData = document.querySelector('input[name=entityUrl]').value;
-        } else {
+    function autoSelectEntityData(entityUrl, entityDataUrl) {
+        if (!entityUrl || entityDataUrl) {
+            requestedEntityDataFor = null;
             return;
         }
-        if (!relatedData) {
+        const looksLikeUrl = entityUrl.includes("://") || entityUrl.startsWith("data:");
+        if (!looksLikeUrl) {
             return;
         }
+        if (requestedEntityDataFor === entityUrl) {
+            return;
+        }
+        requestedEntityDataFor = entityUrl;
         sendMessage({
             type: "request-related-data-url",
-            dataUrl: relatedData,
-            inputKey: button.dataset.inputId,
-            relation: button.dataset.relation,
-            acceptedInputType: button.dataset.dataType,
-            userInteraction: true,
+            dataUrl: entityUrl,
+            inputKey: "entity_data_url",
+            relation: "pre",
+            acceptedInputType: "entity/*",
+            userInteraction: false,
         });
     }
 
-    // Setup event listeners for the entityUrl and clustersUrl input fields
     function setupEventListeners() {
-        const entityInput = document.querySelector('input[name=entityUrl]');
-        entityInput.addEventListener("input", (event) => updatePreview());
-        const clusterInput = document.querySelector('input[name=clustersUrl]');
-        clusterInput.addEventListener("input", (event) => updatePreview());
-
-        // setup extra choose buttons:
-        const chooseRelPointsBtn = document.createElement("button");
-        chooseRelPointsBtn.textContent = "choose related";
-        chooseRelPointsBtn.setAttribute("id", "choose-rel-points");
-        chooseRelPointsBtn.classList.add("qhana-choose-file-button");
-        chooseRelPointsBtn.dataset.inputId = "entity_url";
-        chooseRelPointsBtn.dataset.relation = "pre";
-        chooseRelPointsBtn.dataset.dataType = "entity/vector";
-        chooseRelPointsBtn.setAttribute("disabled", "");
-        chooseRelPointsBtn.setAttribute("role", "button");
-        chooseRelPointsBtn.addEventListener("click", chooseRelatedData);
-        entityInput.parentElement.appendChild(chooseRelPointsBtn);
-
-        const chooseRelLabelsBtn = document.createElement("button");
-        chooseRelLabelsBtn.textContent = "choose related";
-        chooseRelLabelsBtn.setAttribute("id", "choose-rel-labels");
-        chooseRelLabelsBtn.classList.add("qhana-choose-file-button");
-        chooseRelLabelsBtn.dataset.inputId = "clusters_url";
-        chooseRelLabelsBtn.dataset.relation = "post";
-        chooseRelLabelsBtn.dataset.dataType = "entity/label";
-        chooseRelLabelsBtn.setAttribute("disabled", "");
-        chooseRelLabelsBtn.setAttribute("role", "button");
-        chooseRelLabelsBtn.addEventListener("click", chooseRelatedData);
-        clusterInput.parentElement.appendChild(chooseRelLabelsBtn);
+        ["entityUrl", "clustersUrl", "entityDataUrl"].forEach((inputName) => {
+            const input = document.querySelector(`input[name=${inputName}]`);
+            if (!input) {
+                return;
+            }
+            input.addEventListener("input", () => updatePreview());
+            input.addEventListener("change", () => updatePreview());
+        });
     }
 
     async function updatePreview() {
         const entityUrl = document.querySelector('input[name=entityUrl]').value;
         const clustersUrl = document.querySelector('input[name=clustersUrl]').value;
+        const entityDataUrl = document.querySelector('input[name=entityDataUrl]').value;
 
-        const chooseRelEntity = document.querySelector("#choose-rel-points");
-        const chooseRelLabels = document.querySelector("#choose-rel-labels");
-
-        if (entityUrl) {
-            chooseRelLabels.removeAttribute("disabled");
-        } else {
-            chooseRelLabels.setAttribute("disabled", "");
-        }
-        if (clustersUrl) {
-            chooseRelEntity.removeAttribute("disabled");
-        } else {
-            chooseRelEntity.setAttribute("disabled", "");
-        }
+        autoSelectEntityData(entityUrl, entityDataUrl);
 
         // Only an entity Url is required to generate a plot
         if (entityUrl === "" || entityUrl === null) {
@@ -127,6 +95,7 @@
         const params = new URLSearchParams();
         params.set("entityUrl", entityUrl);
         params.set("clustersUrl", clustersUrl ?? "");
+        params.set("entityDataUrl", entityDataUrl ?? "");
         const url = "{{ get_plot_url }}?" + params.toString();
 
         const preview = document.querySelector('.cluster-preview');

--- a/stable_plugins/visualization/complex/cluster_scatter_visualization/cluster_scatter_visualization_templates/cluster_scatter_visualization.html
+++ b/stable_plugins/visualization/complex/cluster_scatter_visualization/cluster_scatter_visualization_templates/cluster_scatter_visualization.html
@@ -73,6 +73,8 @@
             if (!input) {
                 return;
             }
+            // TODO: 'change' alone should be enough and fires less often than
+            // 'input'. Keeping both for now.
             input.addEventListener("input", () => updatePreview());
             input.addEventListener("change", () => updatePreview());
         });

--- a/stable_plugins/visualization/complex/cluster_scatter_visualization/routes.py
+++ b/stable_plugins/visualization/complex/cluster_scatter_visualization/routes.py
@@ -75,8 +75,14 @@ class PluginsView(MethodView):
                     InputDataMetadata(
                         data_type="entity/label",
                         content_type=["application/json", "application/csv"],
-                        required=True,
+                        required=False,
                         parameter="clustersUrl",
+                    ),
+                    InputDataMetadata(
+                        data_type="entity/*",
+                        content_type=["application/json", "application/csv"],
+                        required=False,
+                        parameter="entityDataUrl",
                     ),
                 ],
                 data_output=[
@@ -160,12 +166,13 @@ class MicroFrontend(MethodView):
 def get_plot(data: Mapping):
     entity_url = data.get("entity_url", None)
     clusters_url = data.get("clusters_url", None)
+    entity_data_url = data.get("entity_data_url", None)
     # Only an entity_url is required to generate a plot
     if entity_url is None:
         abort(HTTPStatus.BAD_REQUEST)
     # As the clusters_url can be null, the str method is required
     url_hash = hashlib.sha256(
-        (entity_url + str(clusters_url)).encode("utf-8")
+        (entity_url + str(clusters_url) + str(entity_data_url)).encode("utf-8")
     ).hexdigest()
     plot = DataBlob.get_value(
         ClusterScatterVisualization.instance.identifier, url_hash, None
@@ -178,7 +185,7 @@ def get_plot(data: Mapping):
         ):
             # Add the generate_plot from task.py as an async method
             task_result = generate_plot.s(
-                entity_url, clusters_url, hash_=url_hash
+                entity_url, clusters_url, entity_data_url, hash_=url_hash
             ).apply_async()
             PluginState.set_value(
                 ClusterScatterVisualization.instance.identifier,
@@ -197,7 +204,7 @@ def get_plot(data: Mapping):
         except TimeoutError:
             return Response("Plot not yet created!", HTTPStatus.ACCEPTED)
     if not plot:
-        abort(HTTPStatus.BAD_REQUEST, "Invalid circuit URL!")
+        abort(HTTPStatus.BAD_REQUEST, "Invalid entity URL!")
 
     # Returns the html to the micro frontend
     return Response(plot)
@@ -215,17 +222,21 @@ class ProcessView(MethodView):
     def post(self, arguments):
         entity_url = arguments.get("entity_url", None)
         clusters_url = arguments.get("clusters_url", None)
+        entity_data_url = arguments.get("entity_data_url", None)
         if entity_url is None:
             abort(HTTPStatus.BAD_REQUEST)
         url_hash = hashlib.sha256(
-            (entity_url + str(clusters_url)).encode("utf-8")
+            (entity_url + str(clusters_url) + str(entity_data_url)).encode("utf-8")
         ).hexdigest()
         db_task = ProcessingTask(task_name=process.name)
         db_task.save(commit=True)
 
         # all tasks need to know about db id to load the db entry
         task: chain = process.s(
-            db_id=db_task.id, entity_url=entity_url, clusters_url=clusters_url
+            db_id=db_task.id,
+            entity_url=entity_url,
+            clusters_url=clusters_url,
+            entity_data_url=entity_data_url,
         ) | save_task_result.s(db_id=db_task.id)
         # save errors to db
         task.link_error(save_task_error.s(db_id=db_task.id))

--- a/stable_plugins/visualization/complex/cluster_scatter_visualization/schemas.py
+++ b/stable_plugins/visualization/complex/cluster_scatter_visualization/schemas.py
@@ -26,6 +26,8 @@ class ClusterScatterInputParametersSchema(FrontendFormBaseSchema):
             "label": "Entity Point URL",
             "description": "URL to a json file containing the points.",
             "input_type": "text",
+            "related_to": "clusters_url",
+            "relation": "pre",
         },
     )
     clusters_url = FileUrl(
@@ -37,5 +39,23 @@ class ClusterScatterInputParametersSchema(FrontendFormBaseSchema):
             "label": "Cluster URL",
             "description": "URL to a json file containing the cluster labels.",
             "input_type": "text",
+            "related_to": "entity_url",
+            "relation": "post",
+        },
+    )
+    entity_data_url = FileUrl(
+        required=False,
+        allow_none=True,
+        data_input_type="entity/*",
+        data_content_types=["application/json", "application/csv"],
+        metadata={
+            "label": "Original Entity Data URL",
+            "description": (
+                "Optional URL to original entity data (same IDs). Additional attributes "
+                "are shown in hover and entity links are exposed when available."
+            ),
+            "input_type": "text",
+            "related_to": "entity_url",
+            "relation": "pre",
         },
     )

--- a/stable_plugins/visualization/complex/cluster_scatter_visualization/tasks.py
+++ b/stable_plugins/visualization/complex/cluster_scatter_visualization/tasks.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from json import dumps
 from pathlib import Path
 from tempfile import SpooledTemporaryFile
-from typing import Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Set, Tuple, Union
 
 import muid
 import pandas as pd
@@ -46,13 +47,17 @@ def get_readable_hash(s: str) -> str:
 
 
 def _get_plot(
-    entity_url: str, clusters_url: Optional[str], full_html: bool
+    entity_url: str,
+    clusters_url: Optional[str],
+    entity_data_url: Optional[str],
+    full_html: bool,
 ) -> Tuple[str, str]:
     """Generate a scatter plot from the given url.
 
     Args:
         entity_url (str): the url containing entity coordinates
         clusters_url (str|None): an optional url containing entity cluster labels
+        entity_data_url (str|None): an optional url containing original entity attributes
         full_html (bool): if True, produce a standalone html page, else produce
             an embeddable html snippet.
 
@@ -60,16 +65,17 @@ def _get_plot(
         Tuple[str, str]: html_content, filename
     """
     is_3d = False
-    entities: Dict[str, Dict[str, Union[str, float, int, None]]] = {}
+    entities: Dict[str, Dict[str, Any]] = {}
     with open_url(entity_url) as response:
         mimetype = get_mimetype(response)
         if mimetype is None:
             raise ValueError("Could not determine mimetype.")
         name = retrieve_filename(response)
         for ent in ensure_array(load_entities(response, mimetype=mimetype)):
-            diagram_ent: Dict[str, Union[str, float, int, None]] = {
-                "ID": ent.ID,
-                "name": ent.ID,
+            entity_id = str(ent.ID)
+            diagram_ent: Dict[str, Any] = {
+                "ID": entity_id,
+                "name": entity_id,
             }
             dim = len(ent.values)
             if dim == 0:
@@ -83,7 +89,36 @@ def _get_plot(
                 diagram_ent["z"] = ent.values[2]
                 is_3d = True
             diagram_ent["href"] = ent.href
-            entities[ent.ID] = diagram_ent
+            diagram_ent["attributes"] = {}
+            entities[entity_id] = diagram_ent
+
+    if entity_data_url:
+        with open_url(entity_data_url) as response:
+            mimetype = get_mimetype(response)
+            if mimetype is None:
+                raise ValueError("Could not determine mimetype.")
+            for ent in ensure_dict(load_entities(response, mimetype=mimetype)):
+                entity_id = ent.get("ID")
+                if entity_id is None:
+                    continue
+                diag_ent = entities.get(str(entity_id), None)
+                if diag_ent is None:
+                    continue
+                href = ent.get("href")
+                if href:
+                    diag_ent["href"] = href
+                extra_data: Dict[str, Union[str, float, int, bool, None]] = {}
+                for key, value in ent.items():
+                    if key in {"ID", "href"}:
+                        continue
+                    if value is None or isinstance(value, (str, float, int, bool)):
+                        extra_data[str(key)] = value
+                    else:
+                        try:
+                            extra_data[str(key)] = dumps(value, sort_keys=True)
+                        except TypeError:
+                            extra_data[str(key)] = str(value)
+                diag_ent["attributes"].update(extra_data)
 
     if clusters_url:
         with open_url(clusters_url) as response:
@@ -92,15 +127,17 @@ def _get_plot(
                 raise ValueError("Could not determine mimetype.")
             label_column = "label"
             for ent in ensure_dict(load_entities(response, mimetype=mimetype)):
-                diag_ent: Optional[Dict[str, Union[str, float, int, None]]] = (
-                    entities.get(ent["ID"], None)
-                )
+                entity_id = ent.get("ID")
+                if entity_id is None:
+                    continue
+                diag_ent = entities.get(str(entity_id), None)
                 if diag_ent is None:
                     continue
-                if ent["href"]:
-                    diag_ent["href"] = ent["href"]
+                href = ent.get("href")
+                if href:
+                    diag_ent["href"] = href
                 if label_column not in ent:
-                    entity_columns = list(ent.keys() - {"ID", "href"})
+                    entity_columns = [col for col in ent.keys() if col not in {"ID", "href"}]
                     if len(entity_columns) != 1:
                         raise ValueError(
                             f"Unable to determine label column from {entity_columns}!"
@@ -109,19 +146,44 @@ def _get_plot(
                 diag_ent["label"] = str(ent[label_column])
 
     ent_list = list(entities.values())
+    attributes: Set[str] = {
+        attr
+        for ent in ent_list
+        for attr in ent.get("attributes", {}).keys()
+        if attr is not None
+    }
+    reserved_column_names = {"ID", "name", "URL", "x", "y", "z", "Cluster ID", "size"}
+    attr_to_column_name: Dict[str, str] = {}
+    used_column_names: Set[str] = set(reserved_column_names)
+    for attr in sorted(attributes):
+        column_name = attr
+        if column_name in used_column_names:
+            index = 1
+            while f"Entity {attr} ({index})" in used_column_names:
+                index += 1
+            column_name = f"Entity {attr} ({index})"
+        attr_to_column_name[attr] = column_name
+        used_column_names.add(column_name)
 
-    df = pd.DataFrame(
-        {
-            "ID": [e["ID"] for e in ent_list],
-            "name": [e["name"] for e in ent_list],
-            "URL": [e["href"] for e in ent_list],
-            "x": [e["x"] for e in ent_list],
-            "y": [e["y"] for e in ent_list],
-            "z": [e["z"] if is_3d else 0 for e in ent_list],
-            "Cluster ID": [e.get("label", "0") for e in ent_list],
-            "size": [10 for _ in ent_list],
-        }
-    )
+    df_data: Dict[str, Any] = {
+        "ID": [e["ID"] for e in ent_list],
+        "name": [e["name"] for e in ent_list],
+        "URL": [e["href"] for e in ent_list],
+        "x": [e["x"] for e in ent_list],
+        "y": [e["y"] for e in ent_list],
+        "z": [e["z"] if is_3d else 0 for e in ent_list],
+        "Cluster ID": [e.get("label", "0") for e in ent_list],
+        "size": [10 for _ in ent_list],
+    }
+    for attr, column_name in attr_to_column_name.items():
+        df_data[column_name] = [
+            e.get("attributes", {}).get(attr, None) for e in ent_list
+        ]
+    df = pd.DataFrame(df_data)
+
+    hover_data = {"size": False, "URL": True, "z": is_3d}
+    for column_name in attr_to_column_name.values():
+        hover_data[column_name] = True
 
     if is_3d:
         fig = px.scatter_3d(
@@ -133,7 +195,8 @@ def _get_plot(
             hover_name="name",
             color="Cluster ID",
             symbol="Cluster ID",
-            hover_data={"size": False},
+            hover_data=hover_data,
+            custom_data=["URL", "ID"],
         )
     else:
         fig = px.scatter(
@@ -144,24 +207,89 @@ def _get_plot(
             hover_name="name",
             color="Cluster ID",
             symbol="Cluster ID",
-            hover_data={"size": False},
+            hover_data=hover_data,
+            custom_data=["URL", "ID"],
         )
 
-    return fig.to_html(full_html=full_html), Path(name).stem
+    fig.update_layout(clickmode="event+select")
+
+    post_script = """
+const plotElement = document.getElementById('{plot_id}');
+if (plotElement) {
+  const linkContainerId = `${plotElement.id}-entity-link`;
+  let linkContainer = document.getElementById(linkContainerId);
+  if (!linkContainer) {
+    linkContainer = document.createElement('div');
+    linkContainer.id = linkContainerId;
+    linkContainer.style.marginTop = '0.75rem';
+    linkContainer.style.fontSize = '0.9rem';
+    linkContainer.textContent = 'Selected entity link: n/a';
+    plotElement.insertAdjacentElement('afterend', linkContainer);
+  }
+
+  const updateLink = (point) => {
+    const customData = point && point.customdata ? point.customdata : [];
+    const href = typeof customData[0] === 'string' ? customData[0].trim() : '';
+    const entityId = customData[1] || point.hovertext || 'entity';
+
+    linkContainer.replaceChildren();
+    if (!href) {
+      linkContainer.textContent = 'Selected entity link: n/a';
+      return;
+    }
+
+    const label = document.createElement('span');
+    label.textContent = `Selected entity (${entityId}): `;
+    const link = document.createElement('a');
+    link.href = href;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = href;
+    linkContainer.append(label, link);
+  };
+
+  plotElement.on('plotly_hover', (eventData) => {
+    const point = eventData && eventData.points && eventData.points[0];
+    if (point) {
+      updateLink(point);
+    }
+  });
+  plotElement.on('plotly_click', (eventData) => {
+    const point = eventData && eventData.points && eventData.points[0];
+    if (point) {
+      updateLink(point);
+    }
+  });
+}
+"""
+
+    return fig.to_html(full_html=full_html, post_script=post_script), Path(name).stem
 
 
 @CELERY.task(
     name=f"{ClusterScatterVisualization.instance.identifier}.generate_plot", bind=True
 )
-def generate_plot(self, entity_url: str, clusters_url: Optional[str], hash_: str) -> str:
+def generate_plot(
+    self,
+    entity_url: str,
+    clusters_url: Optional[str],
+    entity_data_url: Optional[str],
+    hash_: str,
+) -> str:
 
     TASK_LOGGER.info(
-        f"Generating plot for entites {entity_url} and clusters {clusters_url}..."
+        "Generating plot for entities %s, clusters %s and entity data %s...",
+        entity_url,
+        clusters_url,
+        entity_data_url,
     )
 
     try:
         diagram, _ = _get_plot(
-            entity_url=entity_url, clusters_url=clusters_url, full_html=False
+            entity_url=entity_url,
+            clusters_url=clusters_url,
+            entity_data_url=entity_data_url,
+            full_html=False,
         )
     except HTTPError:
         DataBlob.set_value(ClusterScatterVisualization.instance.identifier, hash_, b"")
@@ -182,9 +310,18 @@ def generate_plot(self, entity_url: str, clusters_url: Optional[str], hash_: str
 
 
 @CELERY.task(name=f"{ClusterScatterVisualization.instance.identifier}.process", bind=True)
-def process(self, db_id: str, entity_url: str, clusters_url: str) -> str:
+def process(
+    self,
+    db_id: str,
+    entity_url: str,
+    clusters_url: Optional[str],
+    entity_data_url: Optional[str],
+) -> str:
     diagram, name = _get_plot(
-        entity_url=entity_url, clusters_url=clusters_url, full_html=True
+        entity_url=entity_url,
+        clusters_url=clusters_url,
+        entity_data_url=entity_data_url,
+        full_html=True,
     )
 
     # Html needs to be saved as bytes, so it can be stored in a DataBlob

--- a/stable_plugins/visualization/complex/cluster_scatter_visualization/tasks.py
+++ b/stable_plugins/visualization/complex/cluster_scatter_visualization/tasks.py
@@ -15,7 +15,7 @@
 from json import dumps
 from pathlib import Path
 from tempfile import SpooledTemporaryFile
-from typing import Any, Dict, Optional, Set, Tuple, Union
+from typing import Any, Dict, Optional, Set, Tuple
 
 import muid
 import pandas as pd
@@ -107,18 +107,17 @@ def _get_plot(
                 href = ent.get("href")
                 if href:
                     diag_ent["href"] = href
-                extra_data: Dict[str, Union[str, float, int, bool, None]] = {}
+                attributes_dict = diag_ent["attributes"]
                 for key, value in ent.items():
                     if key in {"ID", "href"}:
                         continue
                     if value is None or isinstance(value, (str, float, int, bool)):
-                        extra_data[str(key)] = value
+                        attributes_dict[str(key)] = value
                     else:
                         try:
-                            extra_data[str(key)] = dumps(value, sort_keys=True)
+                            attributes_dict[str(key)] = dumps(value, sort_keys=True)
                         except TypeError:
-                            extra_data[str(key)] = str(value)
-                diag_ent["attributes"].update(extra_data)
+                            attributes_dict[str(key)] = str(value)
 
     if clusters_url:
         with open_url(clusters_url) as response:
@@ -137,9 +136,7 @@ def _get_plot(
                 if href:
                     diag_ent["href"] = href
                 if label_column not in ent:
-                    entity_columns = [
-                        col for col in ent.keys() if col not in {"ID", "href"}
-                    ]
+                    entity_columns = list(ent.keys() - {"ID", "href"})
                     if len(entity_columns) != 1:
                         raise ValueError(
                             f"Unable to determine label column from {entity_columns}!"
@@ -154,18 +151,15 @@ def _get_plot(
         for attr in ent.get("attributes", {}).keys()
         if attr is not None
     }
+    # Fixed columns for the DataFrame below: identity (ID, name, URL),
+    # plot axes (x, y, z), the cluster label column, and the marker size column.
+    # User-supplied attribute names that collide with any of these are prefixed
+    # with "Entity ".
     reserved_column_names = {"ID", "name", "URL", "x", "y", "z", "Cluster ID", "size"}
-    attr_to_column_name: Dict[str, str] = {}
-    used_column_names: Set[str] = set(reserved_column_names)
-    for attr in sorted(attributes):
-        column_name = attr
-        if column_name in used_column_names:
-            index = 1
-            while f"Entity {attr} ({index})" in used_column_names:
-                index += 1
-            column_name = f"Entity {attr} ({index})"
-        attr_to_column_name[attr] = column_name
-        used_column_names.add(column_name)
+    attr_to_column_name: Dict[str, str] = {
+        attr: f"Entity {attr}" if attr in reserved_column_names else attr
+        for attr in sorted(attributes)
+    }
 
     df_data: Dict[str, Any] = {
         "ID": [e["ID"] for e in ent_list],

--- a/stable_plugins/visualization/complex/cluster_scatter_visualization/tasks.py
+++ b/stable_plugins/visualization/complex/cluster_scatter_visualization/tasks.py
@@ -137,7 +137,9 @@ def _get_plot(
                 if href:
                     diag_ent["href"] = href
                 if label_column not in ent:
-                    entity_columns = [col for col in ent.keys() if col not in {"ID", "href"}]
+                    entity_columns = [
+                        col for col in ent.keys() if col not in {"ID", "href"}
+                    ]
                     if len(entity_columns) != 1:
                         raise ValueError(
                             f"Unable to determine label column from {entity_columns}!"
@@ -176,9 +178,7 @@ def _get_plot(
         "size": [10 for _ in ent_list],
     }
     for attr, column_name in attr_to_column_name.items():
-        df_data[column_name] = [
-            e.get("attributes", {}).get(attr, None) for e in ent_list
-        ]
+        df_data[column_name] = [e.get("attributes", {}).get(attr, None) for e in ent_list]
     df = pd.DataFrame(df_data)
 
     hover_data = {"size": False, "URL": True, "z": is_3d}

--- a/stable_plugins/visualization/complex/cluster_scatter_visualization/tasks.py
+++ b/stable_plugins/visualization/complex/cluster_scatter_visualization/tasks.py
@@ -181,7 +181,9 @@ def _get_plot(
         df_data[column_name] = [e.get("attributes", {}).get(attr, None) for e in ent_list]
     df = pd.DataFrame(df_data)
 
-    hover_data = {"size": False, "URL": True, "z": is_3d}
+    # The URL is kept in custom_data for the click handler, but not shown in the
+    # hover tooltip
+    hover_data = {"size": False, "URL": False, "z": is_3d}
     for column_name in attr_to_column_name.values():
         hover_data[column_name] = True
 
@@ -223,7 +225,7 @@ if (plotElement) {
     linkContainer.id = linkContainerId;
     linkContainer.style.marginTop = '0.75rem';
     linkContainer.style.fontSize = '0.9rem';
-    linkContainer.textContent = 'Selected entity link: n/a';
+    linkContainer.textContent = 'Click a point to show its entity link';
     plotElement.insertAdjacentElement('afterend', linkContainer);
   }
 
@@ -234,7 +236,7 @@ if (plotElement) {
 
     linkContainer.replaceChildren();
     if (!href) {
-      linkContainer.textContent = 'Selected entity link: n/a';
+      linkContainer.textContent = `Selected entity (${entityId}) has no link`;
       return;
     }
 
@@ -248,12 +250,7 @@ if (plotElement) {
     linkContainer.append(label, link);
   };
 
-  plotElement.on('plotly_hover', (eventData) => {
-    const point = eventData && eventData.points && eventData.points[0];
-    if (point) {
-      updateLink(point);
-    }
-  });
+  // The link reflects the selected entity
   plotElement.on('plotly_click', (eventData) => {
     const point = eventData && eventData.points && eventData.points[0];
     if (point) {


### PR DESCRIPTION
### Changes

The `cluster_scatter_visualization` plugin can now be enriched with the original entity data, shows that data on hover, and exposes a clickable link to the selected entity.

The clustering plugins are aligned to an extend. Discuss for further changes in new issues.

## Open / follow-up

- [ ] Classification-plugin symbol consistency: classification plots use `symbol=type` (train/test), which differs from the visualization plugin's `symbol=group`. 
- [ ] No automated tests for the plugin.
- [ ] Hover attribute volume: every attribute in the entity-data file is shown, maybe filter/truncate/choosing-parameter


### Testing

 - Ran the plugin runner local to check how it looks.
 - Ran black