### PR TITLE
Parse taxonomy mappings to array

### DIFF
--- a/docs/data-formats/examples/graphs.rst
+++ b/docs/data-formats/examples/graphs.rst
@@ -50,42 +50,38 @@ graph/taxonomy
 
 Same as ``graph/tree``.
 
-Taxonomy nodes carry an optional ``mapping`` field that assigns one or more
-numeric values to a node. A mapping may hold a single value, several values, or
-none at all. This lets downstream plugins attach numeric information to
-categorical taxonomy values, for example a score, a weight, or a coordinate
-vector.
+**Taxonomy Mappings**
+
+Taxonomy nodes can carry an optional ``mapping`` field that assigns one or more numeric values to a node.
+A mapping may hold a single value, several values, or none at all.
+This lets downstream plugins attach numeric information to categorical taxonomy values, for example a score, a weight, or a coordinate vector.
 
 Each node entity exposes two related fields:
 
-.. list-table::
-   :header-rows: 1
-   :widths: 20 80
+- ``mapping_raw``: The original mapping string as authored on the taxonomy item.
+  Values are separated by spaces, for example ``"1"`` or ``"-1 0 2.5"``.
 
-   * - field
-     - description
-   * - ``mapping_raw``
-     - The original mapping string as authored on the taxonomy item, preserved
-       verbatim. Values are separated by spaces, for example ``"1"`` or
-       ``"1 0 2.5"``. An empty string means no mapping was provided.
-   * - ``mapping``
-     - The parsed mapping as a list of floats. Empty tokens (from repeated or
-       trailing spaces) are dropped. A missing or empty ``mapping_raw`` yields
-       an empty list.
+- ``mapping``: The parsed mapping as a list of floats.
+  Empty tokens (from repeated or trailing spaces) are dropped. A missing or empty ``mapping_raw`` yields an empty list.
 
-When at least one node in a taxonomy defines a mapping, all ``mapping`` lists
-are padded to the same length so every node has the same number of values. The
-length is that of the longest mapping in the taxonomy, and shorter lists are
-right-padded with zeros. When no node defines a mapping, every ``mapping`` stays
-an empty list and no padding is applied.
+When at least one node in a taxonomy defines a mapping, all ``mapping`` lists are padded to the same length so every node has the same number of values. 
+The length is that of the longest mapping in the taxonomy, and shorter lists are right-padded with zeros.
+When no node defines a mapping, every ``mapping`` stays an empty list and no padding is applied.
 
 .. code-block:: json
 
    {
-       "ID": "t_Gattung_3",
+       "ID": "t_Gattung_4",
        "tax_item_name": "Sinfonie",
        "description": "",
        "mapping_raw": "1 0 2.5",
        "mapping": [1.0, 0.0, 2.5]
+   },
+   {
+       "ID": "t_Gattung_5",
+       "tax_item_name": "Sinfonietta",
+       "description": "",
+       "mapping_raw": "1 2",
+       "mapping": [1.0, 2.0, 0.0]
    }
 

--- a/docs/data-formats/examples/graphs.rst
+++ b/docs/data-formats/examples/graphs.rst
@@ -48,5 +48,44 @@ Edges may have a weight or any other attribute according to the definition of re
 graph/taxonomy
 ^^^^^^^^^^^^^^
 
-Same as ``graph/tree``
+Same as ``graph/tree``.
+
+Taxonomy nodes carry an optional ``mapping`` field that assigns one or more
+numeric values to a node. A mapping may hold a single value, several values, or
+none at all. This lets downstream plugins attach numeric information to
+categorical taxonomy values, for example a score, a weight, or a coordinate
+vector.
+
+Each node entity exposes two related fields:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - field
+     - description
+   * - ``mapping_raw``
+     - The original mapping string as authored on the taxonomy item, preserved
+       verbatim. Values are separated by spaces, for example ``"1"`` or
+       ``"1 0 2.5"``. An empty string means no mapping was provided.
+   * - ``mapping``
+     - The parsed mapping as a list of floats. Empty tokens (from repeated or
+       trailing spaces) are dropped. A missing or empty ``mapping_raw`` yields
+       an empty list.
+
+When at least one node in a taxonomy defines a mapping, all ``mapping`` lists
+are padded to the same length so every node has the same number of values. The
+length is that of the longest mapping in the taxonomy, and shorter lists are
+right-padded with zeros. When no node defines a mapping, every ``mapping`` stays
+an empty list and no padding is applied.
+
+.. code-block:: json
+
+   {
+       "ID": "t_Gattung_3",
+       "tax_item_name": "Sinfonie",
+       "description": "",
+       "mapping_raw": "1 0 2.5",
+       "mapping": [1.0, 0.0, 2.5]
+   }
 

--- a/stable_plugins/muse/muse_for_music/tasks.py
+++ b/stable_plugins/muse/muse_for_music/tasks.py
@@ -191,10 +191,14 @@ def import_data(self, db_id: int) -> str:
         taxonomy_urls = client.get_taxonomies()
         tmp_zip_file = SpooledTemporaryFile(mode="wb")
         zip_file = ZipFile(tmp_zip_file, "w")
+        warnings: list[str] = []
 
         for taxonomy_url in taxonomy_urls:
             taxonomy = client.get_taxonomy(taxonomy_url)
-            taxonomy_entity = taxonomy_to_entity(taxonomy).to_dict()
+            taxonomy_entity, taxonomy_warnings = taxonomy_to_entity(taxonomy)
+            taxonomy_entity = taxonomy_entity.to_dict()
+            if taxonomy_warnings is not None:
+                warnings.append(taxonomy_warnings)
             zip_file.writestr(
                 taxonomy_entity["GRAPH_ID"] + ".json", json.dumps(taxonomy_entity)
             )
@@ -225,7 +229,9 @@ def import_data(self, db_id: int) -> str:
                 "application/json",
             )
 
-    return "Import finished."
+        return "Import finished." + (
+            "\nWarnings:\n" + "\n".join(f"- {w}" for w in warnings) if warnings else ""
+        )
 
 
 def get_muse_for_music_url_from_registry() -> Optional[str]:

--- a/stable_plugins/muse/muse_for_music/tests/test_util.py
+++ b/stable_plugins/muse/muse_for_music/tests/test_util.py
@@ -50,11 +50,11 @@ def _by_id(entities):
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
-        pytest.param("1,2,3", [1.0, 2.0, 3.0], id="basic"),
-        pytest.param("  1 ,  2.5 , 3 ", [1.0, 2.5, 3.0], id="strips-whitespace"),
+        pytest.param("1 2 3", [1.0, 2.0, 3.0], id="basic"),
+        pytest.param("  1   2.5   3 ", [1.0, 2.5, 3.0], id="collapses-whitespace"),
         pytest.param("", [], id="empty-string"),
         pytest.param("   ", [], id="blank-string"),
-        pytest.param("1,,2,", [1.0, 2.0], id="skips-empty-tokens"),
+        pytest.param("1  2 ", [1.0, 2.0], id="skips-empty-tokens"),
     ],
 )
 def test_parse_mapping(raw, expected):
@@ -63,24 +63,24 @@ def test_parse_mapping(raw, expected):
 
 def test_parse_mapping_bad_token_raises():
     with pytest.raises(ValueError, match="bad token at index 1: 'x'"):
-        _parse_taxonomy_mapping("1,x,3")
+        _parse_taxonomy_mapping("1 x 3")
 
 
 def test_tree_mapping_parsed_and_raw_kept():
-    root = _node(1, "root", mapping="1,2,3", children=[])
+    root = _node(1, "root", mapping="1 2 3", children=[])
     result = taxonomy_to_entity(_build_taxonomy(root))
 
     entities = _by_id(result.entities)
     assert entities["t_Test_1"]["mapping"] == [1.0, 2.0, 3.0]
-    assert entities["t_Test_1"]["mapping_raw"] == "1,2,3"
+    assert entities["t_Test_1"]["mapping_raw"] == "1 2 3"
 
 
 def test_tree_mapping_padded_to_common_dimension():
     root = _node(
         1,
         "root",
-        mapping="1,2",
-        children=[_node(2, "child", mapping="3,4,5")],
+        mapping="1 2",
+        children=[_node(2, "child", mapping="3 4 5")],
     )
     result = taxonomy_to_entity(_build_taxonomy(root))
 
@@ -89,14 +89,14 @@ def test_tree_mapping_padded_to_common_dimension():
     assert entities["t_Test_1"]["mapping"] == [1.0, 2.0, 0]
     assert entities["t_Test_2"]["mapping"] == [3.0, 4.0, 5.0]
     # padding does not alter the preserved raw string
-    assert entities["t_Test_1"]["mapping_raw"] == "1,2"
+    assert entities["t_Test_1"]["mapping_raw"] == "1 2"
 
 
 def test_tree_missing_mapping_defaults_to_empty_then_padded():
     root = _node(
         1,
         "root",  # no mapping key at all
-        children=[_node(2, "child", mapping="7,8")],
+        children=[_node(2, "child", mapping="7 8")],
     )
     result = taxonomy_to_entity(_build_taxonomy(root))
 
@@ -117,7 +117,7 @@ def test_tree_no_mappings_leaves_empty_lists_unpadded():
 
 
 def test_tree_na_item_mapping_parsed_and_padded():
-    root = _node(1, "root", mapping="1,2,3", children=[])
+    root = _node(1, "root", mapping="1 2 3", children=[])
     na_item = {"id": 99, "name": "na", "mapping": "9"}
     result = taxonomy_to_entity(_build_taxonomy(root, na_item=na_item))
 
@@ -131,7 +131,7 @@ def test_tree_na_item_mapping_parsed_and_padded():
 
 
 def test_tree_bad_mapping_token_raises():
-    root = _node(1, "root", mapping="1,bad,3", children=[])
+    root = _node(1, "root", mapping="1 bad 3", children=[])
     with pytest.raises(ValueError, match="bad token at index 1"):
         taxonomy_to_entity(_build_taxonomy(root))
 
@@ -139,7 +139,7 @@ def test_tree_bad_mapping_token_raises():
 def test_list_mapping_parsed_and_padded():
     items = [
         {"id": 1, "name": "a", "mapping": "1.5"},
-        {"id": 2, "name": "b", "mapping": "2.5,3.5"},
+        {"id": 2, "name": "b", "mapping": "2.5 3.5"},
     ]
     result = taxonomy_to_entity(_build_taxonomy(items, kind="list"))
 
@@ -151,7 +151,7 @@ def test_list_mapping_parsed_and_padded():
 
 
 def test_list_na_item_mapping_parsed():
-    items = [{"id": 1, "name": "a", "mapping": "1,2"}]
+    items = [{"id": 1, "name": "a", "mapping": "1 2"}]
     na_item = {"id": 5, "name": "na", "mapping": "4"}
     result = taxonomy_to_entity(_build_taxonomy(items, na_item=na_item, kind="list"))
 

--- a/stable_plugins/muse/muse_for_music/tests/test_util.py
+++ b/stable_plugins/muse/muse_for_music/tests/test_util.py
@@ -144,6 +144,41 @@ def test_tree_bad_mapping_token_returns_warning():
     assert "1 bad 3" in warnings
 
 
+def test_tree_multiple_invalid_mappings_all_appear_in_warning():
+    root = _node(
+        1,
+        "root",
+        mapping="1 bad 3",
+        children=[
+            _node(2, "child_a", mapping="bad 1 2"),
+            _node(3, "child_b", mapping="4 5 also_bad"),
+        ],
+    )
+    _, warnings = taxonomy_to_entity(_build_taxonomy(root))
+
+    assert warnings == (
+        "Invalid mappings for taxonomy t_Test:\n"
+        "  root: 1 bad 3\n"
+        "  child_a: bad 1 2\n"
+        "  child_b: 4 5 also_bad"
+    )
+
+
+def test_list_multiple_invalid_mappings_all_appear_in_warning():
+    items = [
+        {"id": 1, "name": "item_good", "mapping": "1.0 2.0"},
+        {"id": 2, "name": "item_bad_one", "mapping": "3 oops"},
+        {"id": 3, "name": "item_bad_two", "mapping": "nope 7"},
+    ]
+    _, warnings = taxonomy_to_entity(_build_taxonomy(items, kind="list"))
+
+    assert warnings == (
+        "Invalid mappings for taxonomy t_Test:\n"
+        "  item_bad_one: 3 oops\n"
+        "  item_bad_two: nope 7"
+    )
+
+
 def test_list_mapping_parsed_and_padded():
     items = [
         {"id": 1, "name": "a", "mapping": "1.5"},

--- a/stable_plugins/muse/muse_for_music/tests/test_util.py
+++ b/stable_plugins/muse/muse_for_music/tests/test_util.py
@@ -48,31 +48,32 @@ def _by_id(entities):
 
 
 @pytest.mark.parametrize(
-    ("raw", "expected"),
+    ("name", "raw", "expected_nums", "expected_error"),
     [
-        pytest.param("1 2 3", [1.0, 2.0, 3.0], id="basic"),
-        pytest.param("  1   2.5   3 ", [1.0, 2.5, 3.0], id="collapses-whitespace"),
-        pytest.param("", [], id="empty-string"),
-        pytest.param("   ", [], id="blank-string"),
-        pytest.param("1  2 ", [1.0, 2.0], id="skips-empty-tokens"),
+        pytest.param("n", "1 2 3", [1.0, 2.0, 3.0], None, id="basic"),
+        pytest.param(
+            "n", "  1   2.5   3 ", [1.0, 2.5, 3.0], None, id="collapses-whitespace"
+        ),
+        pytest.param("n", "", [], None, id="empty-string"),
+        pytest.param("n", "   ", [], None, id="blank-string"),
+        pytest.param("n", "1  2 ", [1.0, 2.0], None, id="skips-empty-tokens"),
+        pytest.param("n", "1  2 bad", [], "n: 1  2 bad", id="invalid-mapping"),
     ],
 )
-def test_parse_mapping(raw, expected):
-    assert _parse_taxonomy_mapping(raw) == expected
-
-
-def test_parse_mapping_bad_token_raises():
-    with pytest.raises(ValueError, match="bad token at index 1: 'x'"):
-        _parse_taxonomy_mapping("1 x 3")
+def test_parse_mapping(name, raw, expected_nums, expected_error):
+    nums, error = _parse_taxonomy_mapping(name, raw)
+    assert nums == expected_nums
+    assert error == expected_error
 
 
 def test_tree_mapping_parsed_and_raw_kept():
     root = _node(1, "root", mapping="1 2 3", children=[])
-    result = taxonomy_to_entity(_build_taxonomy(root))
+    result, warnings = taxonomy_to_entity(_build_taxonomy(root))
 
     entities = _by_id(result.entities)
     assert entities["t_Test_1"]["mapping"] == [1.0, 2.0, 3.0]
     assert entities["t_Test_1"]["mapping_raw"] == "1 2 3"
+    assert warnings is None
 
 
 def test_tree_mapping_padded_to_common_dimension():
@@ -82,14 +83,15 @@ def test_tree_mapping_padded_to_common_dimension():
         mapping="1 2",
         children=[_node(2, "child", mapping="3 4 5")],
     )
-    result = taxonomy_to_entity(_build_taxonomy(root))
+    result, warnings = taxonomy_to_entity(_build_taxonomy(root))
 
     entities = _by_id(result.entities)
     # widest mapping has 3 entries, so the shorter one is zero padded
-    assert entities["t_Test_1"]["mapping"] == [1.0, 2.0, 0]
+    assert entities["t_Test_1"]["mapping"] == [1.0, 2.0, 0.0]
     assert entities["t_Test_2"]["mapping"] == [3.0, 4.0, 5.0]
     # padding does not alter the preserved raw string
     assert entities["t_Test_1"]["mapping_raw"] == "1 2"
+    assert warnings is None
 
 
 def test_tree_missing_mapping_defaults_to_empty_then_padded():
@@ -98,42 +100,48 @@ def test_tree_missing_mapping_defaults_to_empty_then_padded():
         "root",  # no mapping key at all
         children=[_node(2, "child", mapping="7 8")],
     )
-    result = taxonomy_to_entity(_build_taxonomy(root))
+    result, warnings = taxonomy_to_entity(_build_taxonomy(root))
 
     entities = _by_id(result.entities)
-    assert entities["t_Test_1"]["mapping"] == [0, 0]
+    assert entities["t_Test_1"]["mapping"] == [0.0, 0.0]
     assert entities["t_Test_1"]["mapping_raw"] == ""
     assert entities["t_Test_2"]["mapping"] == [7.0, 8.0]
+    assert warnings is None
 
 
 def test_tree_no_mappings_leaves_empty_lists_unpadded():
     root = _node(1, "root", children=[_node(2, "child")])
-    result = taxonomy_to_entity(_build_taxonomy(root))
+    result, warnings = taxonomy_to_entity(_build_taxonomy(root))
 
     entities = _by_id(result.entities)
     # mapping_dimension is 0, so no padding happens at all
     assert entities["t_Test_1"]["mapping"] == []
     assert entities["t_Test_2"]["mapping"] == []
+    assert warnings is None
 
 
 def test_tree_na_item_mapping_parsed_and_padded():
     root = _node(1, "root", mapping="1 2 3", children=[])
     na_item = {"id": 99, "name": "na", "mapping": "9"}
-    result = taxonomy_to_entity(_build_taxonomy(root, na_item=na_item))
+    result, warnings = taxonomy_to_entity(_build_taxonomy(root, na_item=na_item))
 
     entities = _by_id(result.entities)
     na = entities["t_Test_na"]
     assert na["tax_item_name"] == "na"
-    assert na["mapping"] == [9.0, 0, 0]
+    assert na["mapping"] == [9.0, 0.0, 0.0]
     assert na["mapping_raw"] == "9"
     # na is linked under the assumed root node
     assert {"source": "t_Test_1", "target": "t_Test_na"} in result.relations
+    assert warnings is None
 
 
-def test_tree_bad_mapping_token_raises():
+def test_tree_bad_mapping_token_returns_warning():
     root = _node(1, "root", mapping="1 bad 3", children=[])
-    with pytest.raises(ValueError, match="bad token at index 1"):
-        taxonomy_to_entity(_build_taxonomy(root))
+    _, warnings = taxonomy_to_entity(_build_taxonomy(root))
+
+    assert warnings is not None
+    assert "root" in warnings
+    assert "1 bad 3" in warnings
 
 
 def test_list_mapping_parsed_and_padded():
@@ -141,23 +149,27 @@ def test_list_mapping_parsed_and_padded():
         {"id": 1, "name": "a", "mapping": "1.5"},
         {"id": 2, "name": "b", "mapping": "2.5 3.5"},
     ]
-    result = taxonomy_to_entity(_build_taxonomy(items, kind="list"))
+    result, warnings = taxonomy_to_entity(_build_taxonomy(items, kind="list"))
 
     entities = _by_id(result.entities)
     assert entities["t_Test_root"]["tax_item_name"] == "root"
-    assert entities["t_Test_root"]["mapping"] == [0, 0]
-    assert entities["t_Test_1"]["mapping"] == [1.5, 0]
+    assert entities["t_Test_root"]["mapping"] == [0.0, 0.0]
+    assert entities["t_Test_1"]["mapping"] == [1.5, 0.0]
     assert entities["t_Test_2"]["mapping"] == [2.5, 3.5]
+    assert warnings is None
 
 
 def test_list_na_item_mapping_parsed():
     items = [{"id": 1, "name": "a", "mapping": "1 2"}]
     na_item = {"id": 5, "name": "na", "mapping": "4"}
-    result = taxonomy_to_entity(_build_taxonomy(items, na_item=na_item, kind="list"))
+    result, warnings = taxonomy_to_entity(
+        _build_taxonomy(items, na_item=na_item, kind="list")
+    )
 
     entities = _by_id(result.entities)
-    assert entities["t_Test_na"]["mapping"] == [4.0, 0]
+    assert entities["t_Test_na"]["mapping"] == [4.0, 0.0]
     assert {"source": "t_Test_root", "target": "t_Test_na"} in result.relations
+    assert warnings is None
 
 
 def test_unknown_taxonomy_type_raises():

--- a/stable_plugins/muse/muse_for_music/tests/test_util.py
+++ b/stable_plugins/muse/muse_for_music/tests/test_util.py
@@ -1,0 +1,170 @@
+# Copyright 2026 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Literal
+
+import pytest
+
+from muse_for_music.util import (
+    _parse_taxonomy_mapping,
+    taxonomy_to_entity,
+)
+
+
+def _build_taxonomy(
+    items, na_item=None, kind: Literal["tree", "list"] = "tree", name="Test"
+):
+    entity = {
+        "_links": {"self": {"href": f"http://localhost/api/taxonomies/list/{name}"}},
+        "taxonomy_type": kind,
+        "items": items,
+    }
+    if na_item is not None:
+        entity["na_item"] = na_item
+    return entity
+
+
+def _node(id_, name, mapping=None, children=None):
+    """Build a tree node, omitting ``mapping`` when not provided."""
+    node = {"id": id_, "name": name, "children": children or []}
+    if mapping is not None:
+        node["mapping"] = mapping
+    return node
+
+
+def _by_id(entities):
+    return {e["ID"]: e for e in entities if isinstance(e, dict)}
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("1,2,3", [1.0, 2.0, 3.0], id="basic"),
+        pytest.param("  1 ,  2.5 , 3 ", [1.0, 2.5, 3.0], id="strips-whitespace"),
+        pytest.param("", [], id="empty-string"),
+        pytest.param("   ", [], id="blank-string"),
+        pytest.param("1,,2,", [1.0, 2.0], id="skips-empty-tokens"),
+    ],
+)
+def test_parse_mapping(raw, expected):
+    assert _parse_taxonomy_mapping(raw) == expected
+
+
+def test_parse_mapping_bad_token_raises():
+    with pytest.raises(ValueError, match="bad token at index 1: 'x'"):
+        _parse_taxonomy_mapping("1,x,3")
+
+
+def test_tree_mapping_parsed_and_raw_kept():
+    root = _node(1, "root", mapping="1,2,3", children=[])
+    result = taxonomy_to_entity(_build_taxonomy(root))
+
+    entities = _by_id(result.entities)
+    assert entities["t_Test_1"]["mapping"] == [1.0, 2.0, 3.0]
+    assert entities["t_Test_1"]["mapping_raw"] == "1,2,3"
+
+
+def test_tree_mapping_padded_to_common_dimension():
+    root = _node(
+        1,
+        "root",
+        mapping="1,2",
+        children=[_node(2, "child", mapping="3,4,5")],
+    )
+    result = taxonomy_to_entity(_build_taxonomy(root))
+
+    entities = _by_id(result.entities)
+    # widest mapping has 3 entries, so the shorter one is zero padded
+    assert entities["t_Test_1"]["mapping"] == [1.0, 2.0, 0]
+    assert entities["t_Test_2"]["mapping"] == [3.0, 4.0, 5.0]
+    # padding does not alter the preserved raw string
+    assert entities["t_Test_1"]["mapping_raw"] == "1,2"
+
+
+def test_tree_missing_mapping_defaults_to_empty_then_padded():
+    root = _node(
+        1,
+        "root",  # no mapping key at all
+        children=[_node(2, "child", mapping="7,8")],
+    )
+    result = taxonomy_to_entity(_build_taxonomy(root))
+
+    entities = _by_id(result.entities)
+    assert entities["t_Test_1"]["mapping"] == [0, 0]
+    assert entities["t_Test_1"]["mapping_raw"] == ""
+    assert entities["t_Test_2"]["mapping"] == [7.0, 8.0]
+
+
+def test_tree_no_mappings_leaves_empty_lists_unpadded():
+    root = _node(1, "root", children=[_node(2, "child")])
+    result = taxonomy_to_entity(_build_taxonomy(root))
+
+    entities = _by_id(result.entities)
+    # mapping_dimension is 0, so no padding happens at all
+    assert entities["t_Test_1"]["mapping"] == []
+    assert entities["t_Test_2"]["mapping"] == []
+
+
+def test_tree_na_item_mapping_parsed_and_padded():
+    root = _node(1, "root", mapping="1,2,3", children=[])
+    na_item = {"id": 99, "name": "na", "mapping": "9"}
+    result = taxonomy_to_entity(_build_taxonomy(root, na_item=na_item))
+
+    entities = _by_id(result.entities)
+    na = entities["t_Test_na"]
+    assert na["tax_item_name"] == "na"
+    assert na["mapping"] == [9.0, 0, 0]
+    assert na["mapping_raw"] == "9"
+    # na is linked under the assumed root node
+    assert {"source": "t_Test_1", "target": "t_Test_na"} in result.relations
+
+
+def test_tree_bad_mapping_token_raises():
+    root = _node(1, "root", mapping="1,bad,3", children=[])
+    with pytest.raises(ValueError, match="bad token at index 1"):
+        taxonomy_to_entity(_build_taxonomy(root))
+
+
+def test_list_mapping_parsed_and_padded():
+    items = [
+        {"id": 1, "name": "a", "mapping": "1.5"},
+        {"id": 2, "name": "b", "mapping": "2.5,3.5"},
+    ]
+    result = taxonomy_to_entity(_build_taxonomy(items, kind="list"))
+
+    entities = _by_id(result.entities)
+    assert entities["t_Test_root"]["tax_item_name"] == "root"
+    assert entities["t_Test_root"]["mapping"] == [0, 0]
+    assert entities["t_Test_1"]["mapping"] == [1.5, 0]
+    assert entities["t_Test_2"]["mapping"] == [2.5, 3.5]
+
+
+def test_list_na_item_mapping_parsed():
+    items = [{"id": 1, "name": "a", "mapping": "1,2"}]
+    na_item = {"id": 5, "name": "na", "mapping": "4"}
+    result = taxonomy_to_entity(_build_taxonomy(items, na_item=na_item, kind="list"))
+
+    entities = _by_id(result.entities)
+    assert entities["t_Test_na"]["mapping"] == [4.0, 0]
+    assert {"source": "t_Test_root", "target": "t_Test_na"} in result.relations
+
+
+def test_unknown_taxonomy_type_raises():
+    entity = {
+        "_links": {"self": {"href": "http://localhost/api/taxonomies/tree/Test"}},
+        "taxonomy_type": "graph",
+        "items": [],
+    }
+    with pytest.raises(ValueError, match="Unknown taxonomy type graph"):
+        taxonomy_to_entity(entity)

--- a/stable_plugins/muse/muse_for_music/util.py
+++ b/stable_plugins/muse/muse_for_music/util.py
@@ -317,7 +317,7 @@ def part_to_entity(entity: Dict):
         ui_href,
         href,
         part_name=_extract(entity, "name"),
-        opus=f'o_{_extract(entity, "opus_id", "int")}',
+        opus=f"o_{_extract(entity, 'opus_id', 'int')}",
         movement=_extract(entity, "movement", "int"),
         length=_extract(entity, "length", "int"),
         measure_start=_extract(entity, "measure_start.measure", "int"),
@@ -483,7 +483,7 @@ def subpart_to_entity(entity, part_id_to_opus_id: Dict[str, str]):
 
     ui_href = href.replace("/api/", "/").removesuffix("/")
 
-    part_id = f'p_{_extract(entity, "part_id", "int")}'
+    part_id = f"p_{_extract(entity, 'part_id', 'int')}"
     dynamic_markings = entity.get("dynamic", {}).get("dynamic_markings", [])
     harmonic_centers = entity.get("harmonics", {}).get("harmonic_centers", [])
 
@@ -656,7 +656,7 @@ def voice_to_entity(
 
     ui_href = href.replace("/api/", "/").removesuffix("/")
 
-    subpart_id = f'sp_{_extract(entity, "subpart_id", "int")}'
+    subpart_id = f"sp_{_extract(entity, 'subpart_id', 'int')}"
     part_id = subpart_id_to_part_id[subpart_id]
 
     sequences = entity.get("composition", {}).get("sequences", [])
@@ -853,29 +853,49 @@ class TaxonomyEntity(NamedTuple):
         return dictionary
 
 
+def _parse_taxonomy_mapping(mapping: str) -> List[float]:
+    nums = []
+
+    for i, tok in enumerate(mapping.strip().split(" ")):
+        tok = tok.strip()
+        if not tok:
+            continue
+
+        try:
+            nums.append(float(tok))
+        except ValueError as e:
+            raise ValueError(f"bad token at index {i}: {tok!r}") from e
+
+    return nums
+
+
 def _parse_tree_node(
     item, tax_id: str, na_item: Optional[Dict] = None
 ) -> Tuple[List[dict], List[Dict[str, str]]]:
     id_ = tax_item_to_id(item, tax_id)
     name = item["name"]
-    entities = [
+    mapping = item.get("mapping", "")
+    entities: List[Dict[str, str | List[float]]] = [
         {
             "ID": id_,
             "tax_item_name": name,
             "description": item.get("description", ""),
-            "mapping": item.get("mapping", ""),
+            "mapping": _parse_taxonomy_mapping(mapping),
+            "mapping_raw": mapping,
         }
     ]
-    relations = []
+    relations: List[Dict[str, str]] = []
 
     if na_item:
         na_id = tax_item_to_id(na_item, tax_id)
+        na_mapping = na_item.get("mapping", "")
         entities.append(
             {
                 "ID": na_id,
                 "tax_item_name": "na",
                 "description": na_item.get("description", ""),
-                "mapping": na_item.get("mapping", ""),
+                "mapping": _parse_taxonomy_mapping(na_mapping),
+                "mapping_raw": na_mapping,
             }
         )
         # assume first node as root
@@ -895,10 +915,16 @@ def _parse_list_to_tree(
     items: List, tax_id: str, na_item: Optional[Dict] = None
 ) -> Tuple[List[dict], List[Dict[str, str]]]:
     root_id = f"{tax_id}_root"
-    entities = [
-        {"ID": root_id, "tax_item_name": "root", "description": "", "mapping": ""}
+    entities: List[Dict[str, str | List[float]]] = [
+        {
+            "ID": root_id,
+            "tax_item_name": "root",
+            "description": "",
+            "mapping": [],
+            "mapping_raw": "",
+        }
     ]
-    relations = []
+    relations: List[Dict[str, str]] = []
 
     if na_item:
         na_id = tax_item_to_id(na_item, tax_id)
@@ -907,7 +933,8 @@ def _parse_list_to_tree(
                 "ID": na_id,
                 "tax_item_name": "na",
                 "description": na_item.get("description", ""),
-                "mapping": na_item.get("mapping", ""),
+                "mapping": _parse_taxonomy_mapping(na_item.get("mapping", "")),
+                "mapping_raw": na_item.get("mapping", ""),
             }
         )
         relations.append({"source": root_id, "target": na_id})
@@ -915,12 +942,14 @@ def _parse_list_to_tree(
     for item in items:
         id_ = tax_item_to_id(item, tax_id)
         name = item["name"]
+        mapping_raw = item.get("mapping", "")
         entities.append(
             {
                 "ID": id_,
                 "tax_item_name": name,
                 "description": item.get("description", ""),
-                "mapping": item.get("mapping", ""),
+                "mapping": _parse_taxonomy_mapping(mapping_raw),
+                "mapping_raw": mapping_raw,
             }
         )
         relations.append({"source": root_id, "target": id_})
@@ -948,6 +977,11 @@ def taxonomy_to_entity(
         )
     else:
         raise ValueError(f"Unknown taxonomy type {entity['taxonomy_type']}")
+
+    mapping_dimension = max((len(e["mapping"]) for e in entities), default=0)
+    if mapping_dimension > 0:
+        for entity in entities:
+            entity["mapping"] += [0] * (mapping_dimension - len(entity["mapping"]))
 
     return TaxonomyEntity(graph_id, tax_type, ref_target, list(entities), relations)
 

--- a/stable_plugins/muse/muse_for_music/util.py
+++ b/stable_plugins/muse/muse_for_music/util.py
@@ -870,7 +870,7 @@ def _parse_taxonomy_mapping(name: str, mapping: str) -> tuple[List[float], Optio
 
 def _parse_tree_node(
     item, tax_id: str, na_item: Optional[Dict] = None
-) -> Tuple[List[dict], List[Dict[str, str]], Optional[str]]:
+) -> Tuple[List[dict], List[Dict[str, str]], List[str]]:
     id_ = tax_item_to_id(item, tax_id)
     name = item["name"]
     mapping_raw = item.get("mapping", "")
@@ -909,25 +909,20 @@ def _parse_tree_node(
 
     for child in item["children"]:
         relations.append({"source": id_, "target": tax_item_to_id(child, tax_id)})
-        new_entities, new_relations, child_warning = _parse_tree_node(child, tax_id)
-        if child_warning is not None:
-            invalid_mappings.append(child_warning)
+        new_entities, new_relations, child_invalid_mappings = _parse_tree_node(
+            child, tax_id
+        )
+        if child_invalid_mappings:
+            invalid_mappings.extend(child_invalid_mappings)
         entities.extend(new_entities)
         relations.extend(new_relations)
 
-    warnings = None
-    if len(invalid_mappings) != 0:
-        warnings = (
-            f"Invalid mapping{'s' if len(invalid_mappings) != 1 else ''} for taxonomy {tax_id}:\n"
-            + "\n".join(f"  {m}" for m in invalid_mappings)
-        )
-
-    return entities, relations, warnings
+    return entities, relations, invalid_mappings
 
 
 def _parse_list_to_tree(
     items: List, tax_id: str, na_item: Optional[Dict] = None
-) -> Tuple[List[dict], List[Dict[str, str]], Optional[str]]:
+) -> Tuple[List[dict], List[Dict[str, str]], List[str]]:
     root_id = f"{tax_id}_root"
     entities: List[Dict[str, str | List[float]]] = [
         {
@@ -976,14 +971,7 @@ def _parse_list_to_tree(
         )
         relations.append({"source": root_id, "target": id_})
 
-    warnings = None
-    if len(invalid_mappings) != 0:
-        warnings = (
-            f"Invalid mapping{'s' if len(invalid_mappings) != 1 else ''} for taxonomy {tax_id}:\n"
-            + "\n".join(f"  {m}" for m in invalid_mappings)
-        )
-
-    return entities, relations, warnings
+    return entities, relations, invalid_mappings
 
 
 def taxonomy_to_entity(
@@ -998,12 +986,12 @@ def taxonomy_to_entity(
     na_item = entity.get("na_item", None)
 
     if entity["taxonomy_type"] == "tree":
-        entities, relations, warnings = _parse_tree_node(
+        entities, relations, invalid_mappings = _parse_tree_node(
             entity["items"], tax_id, na_item=na_item
         )
     elif entity["taxonomy_type"] == "list":
         # gets handled like a tree with depth 1
-        entities, relations, warnings = _parse_list_to_tree(
+        entities, relations, invalid_mappings = _parse_list_to_tree(
             entity["items"], tax_id, na_item=na_item
         )
     else:
@@ -1012,7 +1000,16 @@ def taxonomy_to_entity(
     mapping_dimension = max((len(e["mapping"]) for e in entities), default=0)
     if mapping_dimension > 0:
         for entity in entities:
-            entity["mapping"] += [0.0] * (mapping_dimension - len(entity["mapping"]))
+            entity["mapping"] += [0.0] * max(
+                mapping_dimension - len(entity["mapping"]), 0
+            )
+
+    warnings = None
+    if len(invalid_mappings) != 0:
+        warnings = (
+            f"Invalid mapping{'s' if len(invalid_mappings) != 1 else ''} for taxonomy {tax_id}:\n"
+            + "\n".join(f"  {m}" for m in invalid_mappings)
+        )
 
     return (
         TaxonomyEntity(graph_id, tax_type, ref_target, list(entities), relations),

--- a/stable_plugins/muse/muse_for_music/util.py
+++ b/stable_plugins/muse/muse_for_music/util.py
@@ -1014,9 +1014,10 @@ def taxonomy_to_entity(
         for entity in entities:
             entity["mapping"] += [0.0] * (mapping_dimension - len(entity["mapping"]))
 
-    return TaxonomyEntity(
-        graph_id, tax_type, ref_target, list(entities), relations
-    ), warnings
+    return (
+        TaxonomyEntity(graph_id, tax_type, ref_target, list(entities), relations),
+        warnings,
+    )
 
 
 def _unwrap_optional(type_hint: type) -> type:

--- a/stable_plugins/muse/muse_for_music/util.py
+++ b/stable_plugins/muse/muse_for_music/util.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from json import JSONDecodeError, loads
+from logging import warn
 from typing import (
     Annotated,
     Any,
@@ -853,49 +854,54 @@ class TaxonomyEntity(NamedTuple):
         return dictionary
 
 
-def _parse_taxonomy_mapping(mapping: str) -> List[float]:
+def _parse_taxonomy_mapping(name: str, mapping: str) -> tuple[List[float], Optional[str]]:
     nums = []
-
-    for i, tok in enumerate(mapping.strip().split(" ")):
+    for _, tok in enumerate(mapping.strip().split()):
         tok = tok.strip()
         if not tok:
             continue
-
         try:
             nums.append(float(tok))
-        except ValueError as e:
-            raise ValueError(f"bad token at index {i}: {tok!r}") from e
+        except Exception:
+            return [], f"{name}: {mapping}"
 
-    return nums
+    return nums, None
 
 
 def _parse_tree_node(
     item, tax_id: str, na_item: Optional[Dict] = None
-) -> Tuple[List[dict], List[Dict[str, str]]]:
+) -> Tuple[List[dict], List[Dict[str, str]], Optional[str]]:
     id_ = tax_item_to_id(item, tax_id)
     name = item["name"]
-    mapping = item.get("mapping", "")
+    mapping_raw = item.get("mapping", "")
+    mapping, invalid_mapping = _parse_taxonomy_mapping(name, mapping_raw)
+    invalid_mappings: List[str] = []
+    if invalid_mapping is not None:
+        invalid_mappings.append(invalid_mapping)
     entities: List[Dict[str, str | List[float]]] = [
         {
             "ID": id_,
             "tax_item_name": name,
             "description": item.get("description", ""),
-            "mapping": _parse_taxonomy_mapping(mapping),
-            "mapping_raw": mapping,
+            "mapping": mapping,
+            "mapping_raw": mapping_raw,
         }
     ]
     relations: List[Dict[str, str]] = []
 
     if na_item:
         na_id = tax_item_to_id(na_item, tax_id)
-        na_mapping = na_item.get("mapping", "")
+        na_mapping_raw = na_item.get("mapping", "")
+        na_mapping, invalid_na_mapping = _parse_taxonomy_mapping("na", na_mapping_raw)
+        if invalid_na_mapping is not None:
+            invalid_mappings.append(invalid_na_mapping)
         entities.append(
             {
                 "ID": na_id,
                 "tax_item_name": "na",
                 "description": na_item.get("description", ""),
-                "mapping": _parse_taxonomy_mapping(na_mapping),
-                "mapping_raw": na_mapping,
+                "mapping": na_mapping,
+                "mapping_raw": na_mapping_raw,
             }
         )
         # assume first node as root
@@ -903,17 +909,25 @@ def _parse_tree_node(
 
     for child in item["children"]:
         relations.append({"source": id_, "target": tax_item_to_id(child, tax_id)})
-
-        new_entities, new_relations = _parse_tree_node(child, tax_id)
+        new_entities, new_relations, child_warning = _parse_tree_node(child, tax_id)
+        if child_warning is not None:
+            invalid_mappings.append(child_warning)
         entities.extend(new_entities)
         relations.extend(new_relations)
 
-    return entities, relations
+    warnings = None
+    if len(invalid_mappings) != 0:
+        warnings = (
+            f"Invalid mapping{'s' if len(invalid_mappings) != 1 else ''} for taxonomy {tax_id}:\n"
+            + "\n".join(f"  {m}" for m in invalid_mappings)
+        )
+
+    return entities, relations, warnings
 
 
 def _parse_list_to_tree(
     items: List, tax_id: str, na_item: Optional[Dict] = None
-) -> Tuple[List[dict], List[Dict[str, str]]]:
+) -> Tuple[List[dict], List[Dict[str, str]], Optional[str]]:
     root_id = f"{tax_id}_root"
     entities: List[Dict[str, str | List[float]]] = [
         {
@@ -925,16 +939,21 @@ def _parse_list_to_tree(
         }
     ]
     relations: List[Dict[str, str]] = []
+    invalid_mappings: List[str] = []
 
     if na_item:
         na_id = tax_item_to_id(na_item, tax_id)
+        na_mapping_raw = na_item.get("mapping", "")
+        na_mapping, invalid_na_mapping = _parse_taxonomy_mapping("na", na_mapping_raw)
+        if invalid_na_mapping is not None:
+            invalid_mappings.append(invalid_na_mapping)
         entities.append(
             {
                 "ID": na_id,
                 "tax_item_name": "na",
                 "description": na_item.get("description", ""),
-                "mapping": _parse_taxonomy_mapping(na_item.get("mapping", "")),
-                "mapping_raw": na_item.get("mapping", ""),
+                "mapping": na_mapping,
+                "mapping_raw": na_mapping_raw,
             }
         )
         relations.append({"source": root_id, "target": na_id})
@@ -943,23 +962,33 @@ def _parse_list_to_tree(
         id_ = tax_item_to_id(item, tax_id)
         name = item["name"]
         mapping_raw = item.get("mapping", "")
+        mapping, invalid_mapping = _parse_taxonomy_mapping(name, mapping_raw)
+        if invalid_mapping is not None:
+            invalid_mappings.append(invalid_mapping)
         entities.append(
             {
                 "ID": id_,
                 "tax_item_name": name,
                 "description": item.get("description", ""),
-                "mapping": _parse_taxonomy_mapping(mapping_raw),
+                "mapping": mapping,
                 "mapping_raw": mapping_raw,
             }
         )
         relations.append({"source": root_id, "target": id_})
 
-    return entities, relations
+    warnings = None
+    if len(invalid_mappings) != 0:
+        warnings = (
+            f"Invalid mapping{'s' if len(invalid_mappings) != 1 else ''} for taxonomy {tax_id}:\n"
+            + "\n".join(f"  {m}" for m in invalid_mappings)
+        )
+
+    return entities, relations, warnings
 
 
 def taxonomy_to_entity(
     entity: Dict,
-) -> TaxonomyEntity:
+) -> Tuple[TaxonomyEntity, Optional[str]]:
     graph_id = entity_to_id(entity).id_
     tax_type = "tree"
     ref_target = "taxonomies.zip"
@@ -969,10 +998,12 @@ def taxonomy_to_entity(
     na_item = entity.get("na_item", None)
 
     if entity["taxonomy_type"] == "tree":
-        entities, relations = _parse_tree_node(entity["items"], tax_id, na_item=na_item)
+        entities, relations, warnings = _parse_tree_node(
+            entity["items"], tax_id, na_item=na_item
+        )
     elif entity["taxonomy_type"] == "list":
         # gets handled like a tree with depth 1
-        entities, relations = _parse_list_to_tree(
+        entities, relations, warnings = _parse_list_to_tree(
             entity["items"], tax_id, na_item=na_item
         )
     else:
@@ -981,9 +1012,11 @@ def taxonomy_to_entity(
     mapping_dimension = max((len(e["mapping"]) for e in entities), default=0)
     if mapping_dimension > 0:
         for entity in entities:
-            entity["mapping"] += [0] * (mapping_dimension - len(entity["mapping"]))
+            entity["mapping"] += [0.0] * (mapping_dimension - len(entity["mapping"]))
 
-    return TaxonomyEntity(graph_id, tax_type, ref_target, list(entities), relations)
+    return TaxonomyEntity(
+        graph_id, tax_type, ref_target, list(entities), relations
+    ), warnings
 
 
 def _unwrap_optional(type_hint: type) -> type:


### PR DESCRIPTION
- [x] Import mappings as array of numbers
- [x] normalize mappings on import to same length (per taxonomy)
- [x] Document mapping field for taxonomy datatype

Closes UST-QuAntiL/QHAna4MUSE-EnPro26#37