### PR TITLE
vector concat plugin

### DIFF
--- a/plugins/vector_concat/__init__.py
+++ b/plugins/vector_concat/__init__.py
@@ -1,0 +1,52 @@
+# Copyright 2026 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from flask import Flask
+
+from qhana_plugin_runner.api.util import SecurityBlueprint
+from qhana_plugin_runner.util.plugins import QHAnaPluginBase, plugin_identifier
+
+_plugin_name = "vector-concat"
+__version__ = "v0.1.0"
+_identifier = plugin_identifier(_plugin_name, __version__)
+
+VECTOR_CONCAT_BLP = SecurityBlueprint(
+    _identifier,
+    __name__,
+    description="Vector concatination plugin",
+    template_folder="templates",
+)
+
+
+class VectorConcatPlugin(QHAnaPluginBase):
+    name = _plugin_name
+    version = __version__
+    description = "Concatinate multiple entity/vector files into one"
+    tags = ["preprocessing", "vector"]
+
+    def __init__(self, app: Optional[Flask]) -> None:
+        super().__init__(app)
+
+    def get_api_blueprint(self):
+        return VECTOR_CONCAT_BLP
+
+
+try:
+    from . import routes  # noqa: F401,E402
+except ImportError:
+    # When running `poetry run flask install`, importing the routes will fail, because the dependencies are not
+    # installed yet.
+    pass

--- a/plugins/vector_concat/routes.py
+++ b/plugins/vector_concat/routes.py
@@ -1,0 +1,159 @@
+# Copyright 2026 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http import HTTPStatus
+from itertools import chain
+from json import dumps
+from typing import Mapping
+
+from flask import Response, redirect
+from flask.globals import request
+from flask.helpers import url_for
+from flask.templating import render_template
+from flask.views import MethodView
+from flask_smorest import abort
+from marshmallow import EXCLUDE
+
+from qhana_plugin_runner.api.plugin_schemas import (
+    DataMetadata,
+    EntryPoint,
+    InputDataMetadata,
+    PluginMetadata,
+    PluginMetadataSchema,
+    PluginType,
+)
+from qhana_plugin_runner.db.models.tasks import ProcessingTask
+from qhana_plugin_runner.tasks import save_task_error, save_task_result
+
+from . import VECTOR_CONCAT_BLP, VectorConcatPlugin
+from .schemas import VectorConcatSchema
+from .tasks import calculation_task
+
+
+@VECTOR_CONCAT_BLP.route("/")
+class PluginsView(MethodView):
+    @VECTOR_CONCAT_BLP.response(HTTPStatus.OK, PluginMetadataSchema)
+    @VECTOR_CONCAT_BLP.require_jwt("jwt", optional=True)
+    def get(self):
+        return PluginMetadata(
+            title="Vector concationation plugin",
+            description=VectorConcatPlugin.instance.description,
+            name=VectorConcatPlugin.instance.name,
+            version=VectorConcatPlugin.instance.version,
+            type=PluginType.processing,
+            entry_point=EntryPoint(
+                href=url_for(f"{VECTOR_CONCAT_BLP.name}.CalcView"),
+                ui_href=url_for(f"{VECTOR_CONCAT_BLP.name}.MicroFrontend"),
+                data_input=[
+                    InputDataMetadata(
+                        data_type="entity/vector",
+                        content_type=["application/json", "text/csv"],
+                        required=True,
+                        parameter="urls",
+                    ),
+                ],
+                data_output=[
+                    DataMetadata(
+                        data_type="entity/vector",
+                        content_type=[
+                            "text/csv",
+                            "application/json",
+                        ],
+                        required=True,
+                    )
+                ],
+            ),
+            tags=VectorConcatPlugin.instance.tags,
+        )
+
+
+@VECTOR_CONCAT_BLP.route("/ui/")
+class MicroFrontend(MethodView):
+    @VECTOR_CONCAT_BLP.html_response(
+        HTTPStatus.OK, description="Micro frontend of the vector concat plugin."
+    )
+    @VECTOR_CONCAT_BLP.arguments(
+        VectorConcatSchema(partial=True, unknown=EXCLUDE, validate_errors_as_result=True),
+        location="query",
+        required=False,
+    )
+    @VECTOR_CONCAT_BLP.require_jwt("jwt", optional=True)
+    def get(self, errors):
+        """Return the micro frontend"""
+        return self.render({}, {}, True)
+
+    @VECTOR_CONCAT_BLP.html_response(
+        HTTPStatus.OK,
+        description="Micro frontend of the vector concat plugin.",
+    )
+    @VECTOR_CONCAT_BLP.arguments(
+        VectorConcatSchema(partial=True, unknown=EXCLUDE, validate_errors_as_result=True),
+        location="form",
+        required=False,
+    )
+    @VECTOR_CONCAT_BLP.require_jwt("jwt", optional=True)
+    def post(self, errors):
+        """Return the micro frontend with prerendered inputs."""
+        return self.render(request.form, errors, not errors)
+
+    def render(self, data: Mapping, errors: dict, valid: bool):
+        plugin = VectorConcatPlugin.instance
+        if plugin is None:
+            abort(HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        render_errors = dict(errors) if errors else {}
+        schema = VectorConcatSchema()
+
+        return Response(
+            render_template(
+                "vector-concat.html",
+                name=plugin.name,
+                version=plugin.version,
+                schema=schema,
+                valid=valid,
+                values=data,
+                errors=render_errors,
+                process=url_for(f"{VECTOR_CONCAT_BLP.name}.{CalcView.__name__}"),
+            )
+        )
+
+
+@VECTOR_CONCAT_BLP.route("/process/")
+class CalcView(MethodView):
+    """Start a long running processing task"""
+
+    @VECTOR_CONCAT_BLP.arguments(VectorConcatSchema(unknown=EXCLUDE), location="form")
+    @VECTOR_CONCAT_BLP.response(HTTPStatus.SEE_OTHER)
+    @VECTOR_CONCAT_BLP.require_jwt("jwt", optional=True)
+    def post(self, arguments):
+        """Start the calculation task."""
+        db_task = ProcessingTask(
+            task_name=calculation_task.name,
+            parameters=dumps(arguments),
+        )
+        db_task.save(commit=True)
+
+        # all tasks need to know about db id to load the db entry
+        task: chain = calculation_task.s(db_id=db_task.id) | save_task_result.s(
+            db_id=db_task.id
+        )
+        # save errors to db
+        task.link_error(save_task_error.s(db_id=db_task.id))
+        task.apply_async()
+
+        db_task.save(commit=True)
+
+        return redirect(
+            url_for("tasks-api.TaskView", task_id=str(db_task.id)), HTTPStatus.SEE_OTHER
+        )

--- a/plugins/vector_concat/schemas.py
+++ b/plugins/vector_concat/schemas.py
@@ -1,0 +1,83 @@
+# Copyright 2026 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+import marshmallow as ma
+
+from qhana_plugin_runner.api.util import FrontendFormBaseSchema
+
+_VALID_SUFFIX = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _validate_suffix(value: str):
+    if not value:
+        return
+    if not _VALID_SUFFIX.match(value):
+        raise ma.ValidationError(
+            "Suffix may only contain letters, digits, '.', '_' and '-'."
+        )
+
+
+def _validate_urls(value: str):
+    url_validator = ma.validate.URL(schemes={"http", "https"})
+    errors = []
+    urls = [line.strip() for line in value.splitlines() if line.strip()]
+
+    if not urls:
+        raise ma.ValidationError("At least one URL is required.")
+
+    for i, url in enumerate(urls, start=1):
+        try:
+            url_validator(url)
+        except ma.ValidationError as e:
+            errors.append(f"Line {i}: {e.messages[0]}")
+
+    if errors:
+        raise ma.ValidationError(errors)
+
+
+class VectorConcatSchema(FrontendFormBaseSchema):
+    urls = ma.fields.String(
+        required=True,
+        validate=_validate_urls,
+        metadata={
+            "label": "URLs",
+            "description": "URLs of input entity/vector files",
+            "input_type": "textarea",
+        },
+    )
+    output_format = ma.fields.String(
+        missing="csv",
+        validate=ma.validate.OneOf(("csv", "json")),
+        metadata={
+            "label": "Output Format",
+            "description": "Format of the output data.",
+            "input_type": "select",
+            "options": {"csv": "CSV", "json": "JSON"},
+        },
+    )
+    output_suffix = ma.fields.String(
+        required=False,
+        missing="",
+        validate=_validate_suffix,
+        metadata={
+            "label": "Output File Suffix",
+            "description": (
+                "Optional suffix for the output filename, e.g. 'something' produces 'concatenated_something.csv'."
+                "Leave empty for 'concatenated.csv'."
+            ),
+            "input_type": "text",
+        },
+    )

--- a/plugins/vector_concat/tasks.py
+++ b/plugins/vector_concat/tasks.py
@@ -1,0 +1,95 @@
+# Copyright 2026 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from json import loads
+from tempfile import SpooledTemporaryFile
+from typing import Optional
+
+from celery.utils.log import get_task_logger
+
+from qhana_plugin_runner.celery import CELERY
+from qhana_plugin_runner.db.models.tasks import ProcessingTask
+from qhana_plugin_runner.plugin_utils.entity_marshalling import (
+    ensure_array,
+    load_entities,
+    save_entities,
+)
+from qhana_plugin_runner.requests import get_mimetype, open_url
+from qhana_plugin_runner.storage import STORE
+
+from . import VectorConcatPlugin
+
+TASK_LOGGER = get_task_logger(__name__)
+
+
+@CELERY.task(name=f"{VectorConcatPlugin.instance.identifier}.calculation_task", bind=True)
+def calculation_task(self, db_id: int) -> str:
+    TASK_LOGGER.info(f"Starting new vector concat calculation task with db id {db_id}")
+    task_data: Optional[ProcessingTask] = ProcessingTask.get_by_id(id_=db_id)
+    if task_data is None:
+        msg = f"Could not load task data with id {db_id} to read parameters!"
+        TASK_LOGGER.error(msg)
+        raise KeyError(msg)
+
+    params = loads(task_data.parameters or "{}")
+    urls = params.get("urls", "").splitlines()
+    TASK_LOGGER.info(f"URLS: {urls}")
+    output_format = params.get("output_format", "csv")
+    output_suffix = params.get("output_suffix", "").strip()
+    output_name = f"concatenated_{output_suffix}" if output_suffix else "concatenated"
+
+    entities_list = []
+    for url in urls:
+        with open_url(url, stream=True) as x:
+            mimetype = get_mimetype(x)
+            if not mimetype:
+                raise ValueError(f"Could not determine mimetype of {url}!")
+            entities = list(
+                ensure_array(load_entities(x, mimetype=mimetype), strict=True)
+            )
+            entities_list.append(entities)
+
+    combined = []
+    for entities_tuple in zip(*entities_list, strict=True):
+        e1 = entities_tuple[0]
+        for e in entities_tuple[1:]:
+            assert e.ID == e1.ID
+            assert e.href == e1.href
+
+        values = []
+        for e in entities_tuple:
+            values.extend(e.values)
+
+        entity = {"ID": e1.ID, "href": e1.href}
+        entity.update({f"dim{i}": v for i, v in enumerate(values)})
+        combined.append(entity)
+
+    with SpooledTemporaryFile(mode="w") as output:
+        if output_format == "json":
+            save_entities(combined, output, "application/json")
+            STORE.persist_task_result(
+                db_id,
+                output,
+                f"{output_name}.json",
+                "entity/vector",
+                "application/json",
+            )
+        else:
+            attributes = ["ID", "href"] + [f"dim{i}" for i in range(len(combined[0]) - 2)]
+            save_entities(combined, output, "text/csv", attributes=attributes)
+            STORE.persist_task_result(
+                db_id, output, f"{output_name}.csv", "entity/vector", "text/csv"
+            )
+
+    return "Result stored in file"

--- a/plugins/vector_concat/templates/vector-concat.html
+++ b/plugins/vector_concat/templates/vector-concat.html
@@ -1,0 +1,255 @@
+<!--
+Copyright 2026 QHAna plugin runner contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+{% extends "simple_template.html" %}
+
+{% block head %}
+{{ super() }}
+<style>
+    #data_sources {
+        list-style: none;
+        margin: 0.5em 0 0.75em 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.5em;
+    }
+
+    #data_sources li {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 0.75em;
+        padding: 0.6em 0.8em;
+        border: 1px solid rgba(128, 128, 128, 0.4);
+        border-radius: 8px;
+        background: transparent;
+    }
+
+    #data_sources li p {
+        margin: 0;
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow-wrap: break-word;
+        word-break: break-word;
+        line-height: 1.4;
+    }
+
+    .chip-remove {
+        flex: 0 0 auto;
+        border-radius: 500px;
+        border: none;
+        padding-block: 0.3em;
+        padding-inline: 0.8em;
+        white-space: nowrap;
+    }
+
+    #add_data_source {
+        margin-top: 0.5em;
+    }
+
+    #data_sources_error {
+        margin-top: 0.5em;
+    }
+
+    .qhana-form-field {
+        padding: 0;
+        margin: 0;
+    }
+
+    .qhana-form-field + .qhana-form-field {
+        margin-top: 1.5em;
+    }
+
+    .qhana-form-field .qhana-form-label {
+        display: block;
+        margin: 0 0 0.6em 0;
+        padding: 0;
+    }
+
+    .qhana-form-buttons {
+        margin: 1.5em 0 0 0;
+        padding: 0;
+    }
+
+    .qhana-form-buttons .qhana-form-submit {
+        margin: 0;
+    }
+</style>
+{% endblock head %}
+
+{% block content %}
+<form id="form_main" action="" method="post" data-target="api" class="qhana-form" enctype="multipart/form-data">
+    <div class="qhana-form-field">
+        <label class="qhana-form-label" for="add_data_source">Data Sources</label>
+        <ul id="data_sources" class="qhana-input-wrapper"></ul>
+        <button id="add_data_source" type="button" class="qhana-choose-file-button">
+            Select from Experiment
+        </button>
+        <input type="hidden" name="urls" id="data_sources_input" value="">
+        <p id="data_sources-description" class="qhana-input-description">
+            Select multiple data sources from the experiment to use as input.
+        </p>
+        <p id="data_sources_error" class="qhana-error-message" aria-live="assertive" hidden>
+            Please select at least two data sources.
+        </p>
+    </div>
+
+    <div class="qhana-form-field">
+        <label class="qhana-form-label" for="output_format">Output Format</label>
+        <div class="qhana-input-wrapper">
+            <select class="qhana-form-input" name="outputFormat" id="output_format" autocomplete="off">
+                <option value="csv" {% if values.get("outputFormat", "csv") == "csv" %}selected{% endif %}>CSV</option>
+                <option value="json" {% if values.get("outputFormat") == "json" %}selected{% endif %}>JSON</option>
+            </select>
+        </div>
+        <p id="output_format-description" class="qhana-input-description">
+            Choose the output format for the concatenated vector entities.
+        </p>
+    </div>
+
+    <div class="qhana-form-field">
+        <label class="qhana-form-label" for="output_suffix">Output File Suffix</label>
+        <div class="qhana-input-wrapper">
+            <input type="text" class="qhana-form-input" name="outputSuffix" id="output_suffix"
+                autocomplete="off" pattern="[A-Za-z0-9._-]+"
+                title="Only letters, digits, '.', '_' and '-'."
+                value="{{ values.get('outputSuffix', '') }}">
+        </div>
+        <p id="output_suffix-description" class="qhana-input-description">
+            Optional. Produces e.g. "concatenated_something.csv/json".
+            Leave empty for "concatenated.csv/json".
+        </p>
+        <p id="output_suffix_error" class="qhana-error-message" aria-live="assertive" hidden>
+            Suffix may only contain letters, digits, '.', '_' and '-'.
+        </p>
+    </div>
+
+    <div class="qhana-form-buttons">
+        <button class="qhana-form-submit" type="submit" formaction="{{process}}">submit</button>
+    </div>
+</form>
+{% endblock content %}
+
+{% block script %}
+{{ super() }}
+
+<script>
+    function dataSourceUrls() {
+        return Array.from(document.querySelectorAll("ul#data_sources li[data-url]"))
+            .map(li => li.dataset.url);
+    }
+
+    function updateDataSourcesInput() {
+        document.querySelector("#data_sources_input").value = dataSourceUrls().join("\n");
+    }
+
+    function onChooseNewDataSource(event) {
+        event.preventDefault();
+        sendMessage({
+            type: "request-data-url",
+            inputKey: "dataSource",
+            acceptedInputType: "entity/vector",
+            acceptedContentTypes: ["text/csv", "application/json"],
+        });
+    }
+
+    function onRemoveDataSource(event) {
+        event.preventDefault();
+        event.target.closest("li[data-url]").remove();
+        updateDataSourcesInput();
+        if (window._qhana_microfrontend_state != null) {
+            monitorHeightChanges(window._qhana_microfrontend_state);
+        }
+    }
+
+    function onDataUrlResponse(message) {
+        if (message.inputKey !== "dataSource") {
+            return;
+        }
+
+        const existingEntries = Array.from(document.querySelectorAll(`ul#data_sources li[data-url]`));
+        if (existingEntries.some(li => li.dataset.url === message.href)) {
+            return; // data source already added
+        }
+
+        const container = document.createElement("li");
+        container.dataset.url = message.href;
+        container.dataset.filename = message.filename;
+        container.dataset.version = message.version;
+        container.dataset.dataType = message.dataType;
+        container.dataset.contentType = message.contentType;
+
+        const header = document.createElement("p");
+        container.appendChild(header);
+        header.textContent = `${message.filename} (${message.version}) – ${message.dataType}; ${message.contentType}`;
+
+        const removeBtn = document.createElement("button");
+        container.appendChild(removeBtn);
+        removeBtn.type = "button";
+        removeBtn.classList.add("chip-remove");
+        removeBtn.textContent = "remove";
+        removeBtn.addEventListener("click", onRemoveDataSource);
+
+        document.querySelector("ul#data_sources").appendChild(container);
+        updateDataSourcesInput();
+
+        if (window._qhana_microfrontend_state != null) {
+            monitorHeightChanges(window._qhana_microfrontend_state);
+        }
+    }
+
+    function messageInterceptor(event) {
+        var data = event.data;
+        if ((typeof data !== "string") && (data != null && data.type === "data-url-response")) {
+            onDataUrlResponse(data);
+            return true;
+        }
+        return false; // message event not handled, use default handling
+    }
+
+    const SUFFIX_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+    function customSubmitHandler(event) {
+        if (dataSourceUrls().length < 2) {
+            event.preventDefault();
+            document.querySelector("#data_sources_error").removeAttribute("hidden");
+            return true;
+        }
+        document.querySelector("#data_sources_error").setAttribute("hidden", "hidden");
+
+        const suffix = document.querySelector("#output_suffix").value.trim();
+        const suffixError = document.querySelector("#output_suffix_error");
+        if (suffix !== "" && !SUFFIX_PATTERN.test(suffix)) {
+            event.preventDefault();
+            suffixError.removeAttribute("hidden");
+            return true;
+        }
+        suffixError.setAttribute("hidden", "hidden");
+        return false;
+    }
+
+    if (window._qhana_microfrontend_state != null) {
+        window._qhana_microfrontend_state.formSubmitHandler = customSubmitHandler;
+        window._qhana_microfrontend_state.messageHandler = messageInterceptor;
+    } else {
+        document.querySelector("form#form_main").addEventListener("submit", customSubmitHandler);
+    }
+
+    document.querySelector("button#add_data_source").addEventListener("click", onChooseNewDataSource);
+</script>
+{% endblock script %}

--- a/plugins/vector_concat/tests/test_routes.py
+++ b/plugins/vector_concat/tests/test_routes.py
@@ -1,0 +1,161 @@
+# Copyright 2026 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from http import HTTPStatus
+from urllib.parse import urlsplit
+
+import pytest
+from flask import url_for
+
+from vector_concat import VECTOR_CONCAT_BLP, VectorConcatPlugin
+
+
+def _path(endpoint: str) -> str:
+    return urlsplit(url_for(f"{VECTOR_CONCAT_BLP.name}.{endpoint}")).path
+
+
+def test_metadata_endpoint_returns_full_descriptor(client):
+    resp = client.get(url_for(f"{VECTOR_CONCAT_BLP.name}.PluginsView"))
+    plugin = VectorConcatPlugin.instance
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.get_json()
+
+    assert body["name"] == plugin.name
+    assert body["version"] == plugin.version
+    assert body["title"] == "Vector concationation plugin"
+    assert body["description"] == plugin.description
+    assert body["type"] == "processing"
+    assert body["tags"] == plugin.tags
+
+    entry_point = body["entryPoint"]
+    assert entry_point["href"] == _path("CalcView")
+    assert entry_point["uiHref"] == _path("MicroFrontend")
+    assert entry_point["pluginDependencies"] == []
+
+    assert entry_point["dataInput"] == [
+        {
+            "dataType": "entity/vector",
+            "contentType": ["application/json", "text/csv"],
+            "required": True,
+            "parameter": "urls",
+        }
+    ]
+
+    assert entry_point["dataOutput"] == [
+        {
+            "dataType": "entity/vector",
+            "contentType": ["text/csv", "application/json"],
+            "required": True,
+        }
+    ]
+
+
+def test_microfrontend_renders_form_fields(client):
+    resp = client.get(url_for(f"{VECTOR_CONCAT_BLP.name}.MicroFrontend"))
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.get_data(as_text=True)
+
+    assert "Data Sources" in body
+    assert '<input type="hidden" name="urls" id="data_sources_input" value="">' in body
+
+    assert "Output Format" in body
+    assert '<option value="csv" selected>CSV</option>' in body
+    assert '<option value="json" >JSON</option>' in body
+
+    assert "Output File Suffix" in body
+    assert 'name="outputSuffix"' in body
+
+    assert f'formaction="{_path("CalcView")}"' in body
+    assert 'acceptedInputType: "entity/vector"' in body
+    assert 'acceptedContentTypes: ["text/csv", "application/json"]' in body
+
+
+def test_microfrontend_post_echoes_submitted_output_format(client):
+    resp = client.post(
+        url_for(f"{VECTOR_CONCAT_BLP.name}.MicroFrontend"),
+        data={"urls": "http://example.com/a.csv", "outputFormat": "json"},
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.get_data(as_text=True)
+    assert '<option value="json" selected>JSON</option>' in body
+    assert '<option value="csv" >CSV</option>' in body
+
+
+def test_microfrontend_invalid_post_rerenders_form_without_redirect(client):
+    resp = client.post(
+        url_for(f"{VECTOR_CONCAT_BLP.name}.MicroFrontend"),
+        data={"urls": "not-a-url", "outputFormat": "csv"},
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.get_data(as_text=True)
+    assert '<form id="form_main"' in body
+    assert f'formaction="{_path("CalcView")}"' in body
+
+
+@pytest.mark.parametrize(
+    ("payload", "field", "message"),
+    [
+        ({"urls": "not-a-url"}, "urls", "Line 1: Not a valid URL."),
+        ({}, "urls", "Missing data for required field."),
+        (
+            {"urls": "http://example.com/a.csv", "outputFormat": "xml"},
+            "outputFormat",
+            "Must be one of: csv, json.",
+        ),
+        (
+            {"urls": "http://example.com/a.csv", "outputSuffix": "bad name"},
+            "outputSuffix",
+            "Suffix may only contain letters, digits, '.', '_' and '-'.",
+        ),
+        (
+            {"urls": "http://example.com/a.csv", "outputSuffix": "a/b"},
+            "outputSuffix",
+            "Suffix may only contain letters, digits, '.', '_' and '-'.",
+        ),
+    ],
+)
+def test_process_rejects_invalid_payload(client, payload, field, message):
+    resp = client.post(url_for(f"{VECTOR_CONCAT_BLP.name}.CalcView"), data=payload)
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert resp.get_json()["errors"]["form"][field] == [message]
+
+
+def test_process_valid_payload_redirects_to_task(client):
+    resp = client.post(
+        url_for(f"{VECTOR_CONCAT_BLP.name}.CalcView"),
+        data={"urls": "http://example.com/a.csv", "outputFormat": "csv"},
+    )
+
+    assert resp.status_code == HTTPStatus.SEE_OTHER
+    assert re.fullmatch(r"/tasks/\d+/", urlsplit(resp.headers["Location"]).path)
+
+
+def test_process_accepts_valid_output_suffix(client):
+    resp = client.post(
+        url_for(f"{VECTOR_CONCAT_BLP.name}.CalcView"),
+        data={
+            "urls": "http://example.com/a.csv",
+            "outputFormat": "csv",
+            "outputSuffix": "run_42.v2",
+        },
+    )
+
+    assert resp.status_code == HTTPStatus.SEE_OTHER
+    assert re.fullmatch(r"/tasks/\d+/", urlsplit(resp.headers["Location"]).path)

--- a/plugins/vector_concat/tests/test_schemas.py
+++ b/plugins/vector_concat/tests/test_schemas.py
@@ -1,0 +1,89 @@
+# Copyright 2026 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+from marshmallow import ValidationError
+
+from vector_concat.schemas import VectorConcatSchema
+
+VALID_URL = "http://example.com/data.csv"
+SECOND_URL = "https://example.com/other.json"
+
+
+def _payload(urls: str, **overrides) -> dict:
+    base = {"urls": urls}
+    base.update(overrides)
+    return base
+
+
+def test_single_url_valid_defaults_output_format_to_csv():
+    result = VectorConcatSchema().load(_payload(VALID_URL))
+    assert isinstance(result, dict)
+    assert result["urls"] == VALID_URL
+    assert result["output_format"] == "csv"
+
+
+def test_multiple_urls_valid():
+    urls = f"{VALID_URL}\n{SECOND_URL}"
+    result = VectorConcatSchema().load(_payload(urls))
+    assert isinstance(result, dict)
+    assert result["urls"] == urls
+    assert result["output_format"] == "csv"
+
+
+@pytest.mark.parametrize("fmt", ["csv", "json"])
+def test_output_format_accepted(fmt):
+    result = VectorConcatSchema().load(_payload(VALID_URL, outputFormat=fmt))
+    assert isinstance(result, dict)
+    assert result["output_format"] == fmt
+
+
+def test_blank_lines_between_valid_urls_tolerated():
+    urls = f"{VALID_URL}\n\n   \n{SECOND_URL}"
+    result = VectorConcatSchema().load(_payload(urls))
+    assert isinstance(result, dict)
+    assert result["urls"] == urls
+
+
+def test_unknown_output_format_rejected():
+    with pytest.raises(ValidationError) as exc:
+        VectorConcatSchema().load(_payload(VALID_URL, outputFormat="xml"))
+    assert exc.value.messages == {"outputFormat": ["Must be one of: csv, json."]}
+
+
+def test_urls_required():
+    with pytest.raises(ValidationError) as exc:
+        VectorConcatSchema().load({})
+    assert exc.value.messages == {"urls": ["Missing data for required field."]}
+
+
+@pytest.mark.parametrize("value", ["", "   ", "\n\n", "  \n \n"])
+def test_empty_or_whitespace_urls_rejected(value):
+    with pytest.raises(ValidationError) as exc:
+        VectorConcatSchema().load(_payload(value))
+    assert exc.value.messages == {"urls": ["At least one URL is required."]}
+
+
+def test_single_invalid_url_reports_line_one():
+    with pytest.raises(ValidationError) as exc:
+        VectorConcatSchema().load(_payload("not-a-url"))
+    assert exc.value.messages == {"urls": ["Line 1: Not a valid URL."]}
+
+
+def test_mixed_valid_and_invalid_reports_only_offending_line():
+    urls = f"{VALID_URL}\nnot-a-url"
+    with pytest.raises(ValidationError) as exc:
+        VectorConcatSchema().load(_payload(urls))
+    assert exc.value.messages == {"urls": ["Line 2: Not a valid URL."]}

--- a/plugins/vector_concat/tests/test_tasks.py
+++ b/plugins/vector_concat/tests/test_tasks.py
@@ -1,0 +1,222 @@
+# Copyright 2026 QHAna plugin runner contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import csv
+import json
+
+import pytest
+
+from qhana_plugin_runner.db import DB
+from qhana_plugin_runner.db.models.tasks import ProcessingTask
+from vector_concat.tasks import calculation_task
+
+
+# TODO: could be extracted to utilities file in root test folder if this is usefull for other plugin tests
+class _MockResponse:
+    def __init__(self, content_type: str, *, json_data=None, csv_lines=None):
+        self.headers = {"Content-Type": content_type}
+        self._json_data = json_data
+        self._csv_lines = csv_lines
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def json(self):
+        return self._json_data
+
+    def iter_lines(self, decode_unicode: bool = False, **kwargs):
+        yield from self._csv_lines or ()
+
+
+def _csv_response(header, rows):
+    lines = [",".join(header)]
+    lines += [",".join(str(v) for v in row) for row in rows]
+    return _MockResponse("text/csv", csv_lines=lines)
+
+
+def _json_response(entities):
+    return _MockResponse("application/json", json_data=entities)
+
+
+def _run_task(monkeypatch, url_to_response: dict, params: dict):
+    db_task = ProcessingTask(
+        task_name=calculation_task.name,
+        parameters=json.dumps(params),
+    )
+    db_task.save(commit=True)
+
+    def mock_open_url(url, *args, **kwargs):
+        return url_to_response[url]
+
+    monkeypatch.setattr("vector_concat.tasks.open_url", mock_open_url)
+
+    result = calculation_task.apply(kwargs={"db_id": db_task.id}).get()
+    assert result == "Result stored in file"
+
+    DB.session.expire_all()
+    return db_task.id
+
+
+def _single_output(db_id: int):
+    task = ProcessingTask.get_by_id(db_id)
+    assert task is not None
+    assert len(task.outputs) == 1
+    return task.outputs[0]
+
+
+def _read_json(file_info):
+    with open(file_info.file_storage_data, "r") as fh:
+        return json.load(fh)
+
+
+def _read_csv(file_info):
+    with open(file_info.file_storage_data, "r", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def test_concat_two_csv_inputs_produces_combined_csv(app, monkeypatch):
+    url_a, url_b = "http://example.com/a.csv", "http://example.com/b.csv"
+    responses = {
+        url_a: _csv_response(["ID", "href", "dim0", "dim1"], [("e1", "h1", 1, 2)]),
+        url_b: _csv_response(["ID", "href", "dim0", "dim1"], [("e1", "h1", 3, 4)]),
+    }
+    db_id = _run_task(
+        monkeypatch, responses, {"urls": f"{url_a}\n{url_b}", "output_format": "csv"}
+    )
+
+    output = _single_output(db_id)
+    assert output.file_name == "concatenated.csv"
+    assert output.file_type == "entity/vector"
+    assert output.mimetype == "text/csv"
+
+    rows = _read_csv(output)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["ID"] == "e1"
+    assert row["href"] == "h1"
+    assert [row["dim0"], row["dim1"], row["dim2"], row["dim3"]] == ["1", "2", "3", "4"]
+
+
+def test_concat_two_json_inputs_produces_combined_json(app, monkeypatch):
+    url_a, url_b = "http://example.com/a.json", "http://example.com/b.json"
+    responses = {
+        url_a: _json_response([{"ID": "e1", "href": "h1", "dim0": 1, "dim1": 2}]),
+        url_b: _json_response([{"ID": "e1", "href": "h1", "dim0": 3, "dim1": 4}]),
+    }
+    db_id = _run_task(
+        monkeypatch, responses, {"urls": f"{url_a}\n{url_b}", "output_format": "json"}
+    )
+
+    output = _single_output(db_id)
+    assert output.file_name == "concatenated.json"
+    assert output.file_type == "entity/vector"
+    assert output.mimetype == "application/json"
+
+    entities = _read_json(output)
+    assert len(entities) == 1
+    entity = entities[0]
+    assert entity["ID"] == "e1"
+    assert entity["href"] == "h1"
+    assert [entity["dim0"], entity["dim1"], entity["dim2"], entity["dim3"]] == [
+        1,
+        2,
+        3,
+        4,
+    ]
+
+
+def test_output_suffix_appends_to_csv_filename(app, monkeypatch):
+    url_a, url_b = "http://example.com/a.csv", "http://example.com/b.csv"
+    responses = {
+        url_a: _csv_response(["ID", "href", "dim0"], [("e1", "h1", 1)]),
+        url_b: _csv_response(["ID", "href", "dim0"], [("e1", "h1", 2)]),
+    }
+    db_id = _run_task(
+        monkeypatch,
+        responses,
+        {"urls": f"{url_a}\n{url_b}", "output_format": "csv", "output_suffix": "run42"},
+    )
+
+    output = _single_output(db_id)
+    assert output.file_name == "concatenated_run42.csv"
+
+
+def test_output_suffix_appends_to_json_filename(app, monkeypatch):
+    url_a, url_b = "http://example.com/a.json", "http://example.com/b.json"
+    responses = {
+        url_a: _json_response([{"ID": "e1", "href": "h1", "dim0": 1}]),
+        url_b: _json_response([{"ID": "e1", "href": "h1", "dim0": 2}]),
+    }
+    db_id = _run_task(
+        monkeypatch,
+        responses,
+        {"urls": f"{url_a}\n{url_b}", "output_format": "json", "output_suffix": "run42"},
+    )
+
+    output = _single_output(db_id)
+    assert output.file_name == "concatenated_run42.json"
+
+
+def test_empty_output_suffix_keeps_default_filename(app, monkeypatch):
+    url = "http://example.com/a.csv"
+    responses = {url: _csv_response(["ID", "href", "dim0"], [("e1", "h1", 5)])}
+    db_id = _run_task(monkeypatch, responses, {"urls": url, "output_suffix": "   "})
+
+    output = _single_output(db_id)
+    assert output.file_name == "concatenated.csv"
+
+
+def test_output_format_defaults_to_csv(app, monkeypatch):
+    """When ``output_format`` is absent the task falls back to CSV output."""
+    url = "http://example.com/a.csv"
+    responses = {url: _csv_response(["ID", "href", "dim0"], [("e1", "h1", 5)])}
+    db_id = _run_task(monkeypatch, responses, {"urls": url})
+
+    output = _single_output(db_id)
+    assert output.file_name == "concatenated.csv"
+    assert output.mimetype == "text/csv"
+
+
+def test_mismatched_ids_raise(app, monkeypatch):
+    url_a, url_b = "http://example.com/a.csv", "http://example.com/b.csv"
+    responses = {
+        url_a: _csv_response(["ID", "href", "dim0"], [("e1", "h1", 1)]),
+        url_b: _csv_response(["ID", "href", "dim0"], [("e2", "h1", 2)]),
+    }
+    with pytest.raises(AssertionError):
+        _run_task(
+            monkeypatch, responses, {"urls": f"{url_a}\n{url_b}", "output_format": "csv"}
+        )
+
+
+def test_unequal_row_counts_raise(app, monkeypatch):
+    """``zip(*entities_list, strict=True)`` rejects inputs of differing length."""
+    url_a, url_b = "http://example.com/a.csv", "http://example.com/b.csv"
+    responses = {
+        url_a: _csv_response(["ID", "href", "dim0"], [("e1", "h1", 1), ("e2", "h2", 2)]),
+        url_b: _csv_response(["ID", "href", "dim0"], [("e1", "h1", 3)]),
+    }
+    with pytest.raises(ValueError):
+        _run_task(
+            monkeypatch, responses, {"urls": f"{url_a}\n{url_b}", "output_format": "csv"}
+        )
+
+
+def test_missing_db_id_raises(app):
+    """Task raises ``KeyError`` when no ``ProcessingTask`` row matches the id."""
+    with pytest.raises(KeyError, match="Could not load task data"):
+        calculation_task.apply(kwargs={"db_id": 99999}).get()


### PR DESCRIPTION
Implemented plugin to concatenate multiple entity/vector files into one:

<img width="1488" height="1324" alt="image" src="https://github.com/user-attachments/assets/7a6395f9-2c7c-4fbc-acbd-a0c94650857e" />

The code for the custom template and the multiple input files selection was adapted from the [SQL Editor Plugin](https://github.com/UST-QuAntiL/qhana-plugin-runner/tree/main/stable_plugins/classical_ml/data_preparation/sql_editor).

Example Inputs:
[entity_points_mds_dim_2_metric_metric_from_entity_distances_aggregator_mean_from_transformers_attr_dist_transformer_linear_inverse_from_sym_max_mean_Lgyfoh-Zzmzg.json](https://github.com/user-attachments/files/29175253/entity_points_mds_dim_2_metric_metric_from_entity_distances_aggregator_mean_from_transformers_attr_dist_transformer_linear_inverse_from_sym_max_mean_Lgyfoh-Zzmzg.json)
[one-hot-encoded_points_from_opuses.csv](https://github.com/user-attachments/files/29175254/one-hot-encoded_points_from_opuses.csv)

Output:
[concatenated.csv](https://github.com/user-attachments/files/29175247/concatenated.csv)
[concatenated.json](https://github.com/user-attachments/files/29175248/concatenated.json)
