### PR TITLE
Ignore test files during plugin discovery

### DIFF
--- a/qhana_plugin_runner/util/plugins.py
+++ b/qhana_plugin_runner/util/plugins.py
@@ -239,6 +239,10 @@ def _load_plugins_from_folder(
     for child in folder.iterdir():
         if child.name.startswith("."):
             continue
+        if child.is_file() and child.name.startswith("test_"):
+            continue
+        if child.is_dir() and child.name in {"test", "tests"}:
+            continue
         if child.is_file():
             _try_load_plugin_file(app, child)
         if child.is_dir():


### PR DESCRIPTION
## Description

Prevents the plugin runner from importing test files and test directories during automatic plugin discovery.

Closes UST-QuAntiL/QHAna4MUSE-EnPro26#74.

## Changes

- Ignore files whose names start with `test_`.
- Ignore directories named `test` or `tests`.
- Continue loading regular plugin files and plugin packages.

## Testing

- Existing plugin import tests passed with UTF-8 mode:
  - `2 passed`
- Manual test confirmed that `test_plugin.py` is ignored.
- Manual test confirmed that `test` and `tests` directories are ignored.